### PR TITLE
pine64/pinebook-pro: Add cw2015 fuel gauge to device tree

### DIFF
--- a/boards/pine64/0001-arm64-dts-rockchip-add-fuel-gauge-to-Pinebook-Pro-dt.patch
+++ b/boards/pine64/0001-arm64-dts-rockchip-add-fuel-gauge-to-Pinebook-Pro-dt.patch
@@ -1,0 +1,55 @@
+commit c7c4d698cd2882c4d095aeed43bbad6fc990e998
+Author: Tobias Schramm <t.schramm@manjaro.org>
+Date:   Thu May 28 19:25:50 2020 +0200
+
+    arm64: dts: rockchip: add fuel gauge to Pinebook Pro dts
+    
+    This commit adds cw2015 fuel gauge and battery to the Pinebook Pro dts.
+    
+    Signed-off-by: Tobias Schramm <t.schramm@manjaro.org>
+    Link: https://lore.kernel.org/r/20200528172550.2324722-2-t.schramm@manjaro.org
+    Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+diff --git a/arch/arm/dts/rk3399-pinebook-pro.dts b/arch/arm/dts/rk3399-pinebook-pro.dts
+index cb0245d2226d..8f5b2df01560 100644
+--- a/arch/arm/dts/rk3399-pinebook-pro.dts
++++ b/arch/arm/dts/rk3399-pinebook-pro.dts
+@@ -28,6 +28,13 @@ backlight: edp-backlight {
+ 		pwms = <&pwm0 0 740740 0>;
+ 	};
+ 
++	bat: battery {
++		compatible = "simple-battery";
++		charge-full-design-microamp-hours = <9800000>;
++		voltage-max-design-microvolt = <4350000>;
++		voltage-min-design-microvolt = <3000000>;
++	};
++
+ 	edp_panel: edp-panel {
+ 		compatible = "boe,nv140fhmn49";
+ 		backlight = <&backlight>;
+@@ -741,6 +748,24 @@ usbc_dp: endpoint {
+ 			};
+ 		};
+ 	};
++
++	cw2015@62 {
++		compatible = "cellwise,cw2015";
++		reg = <0x62>;
++		cellwise,battery-profile = /bits/ 8 <
++			0x17 0x67 0x80 0x73 0x6E 0x6C 0x6B 0x63
++			0x77 0x51 0x5C 0x58 0x50 0x4C 0x48 0x36
++			0x15 0x0C 0x0C 0x19 0x5B 0x7D 0x6F 0x69
++			0x69 0x5B 0x0C 0x29 0x20 0x40 0x52 0x59
++			0x57 0x56 0x54 0x4F 0x3B 0x1F 0x7F 0x17
++			0x06 0x1A 0x30 0x5A 0x85 0x93 0x96 0x2D
++			0x48 0x77 0x9C 0xB3 0x80 0x52 0x94 0xCB
++			0x2F 0x00 0x64 0xA5 0xB5 0x11 0xF0 0x11
++		>;
++		cellwise,monitor-interval-ms = <5000>;
++		monitored-battery = <&bat>;
++		power-supplies = <&mains_charger>, <&fusb0>;
++	};
+ };
+ 
+ &i2s1 {

--- a/boards/pine64/pinebook-pro.nix
+++ b/boards/pine64/pinebook-pro.nix
@@ -24,6 +24,7 @@ rockchipRK399 {
     ./0001-rk3399-light-pinebook-power-and-standby-leds-during-.patch
     ./0001-rk3399-pinebook-pro-Support-SPI-flash-boot.patch
     ./0001-rk3399-pinebook-pro-Disable-cdn_dp.patch
+    ./0001-arm64-dts-rockchip-add-fuel-gauge-to-Pinebook-Pro-dt.patch
     ./0005-PBP-Fix-Panel-reset.patch
     (fetchpatch {
       url = "https://patchwork.ozlabs.org/series/232334/mbox/";


### PR DESCRIPTION
This PR adds a device tree patch from mainline Linux for the cw2015 fuel gauge. With this added, the two device trees are mostly identical.