### PR TITLE
rk3399: Workaround UEFI poweroff issues

### DIFF
--- a/support/builders/rockchip-rk3399/0001-HACK-efi_runtime-pretend-we-can-t-reset.patch
+++ b/support/builders/rockchip-rk3399/0001-HACK-efi_runtime-pretend-we-can-t-reset.patch
@@ -1,0 +1,45 @@
+From fdbde526d840f62f76ef6c744f54bc1ce92bdf24 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Sun, 23 May 2021 00:33:12 -0400
+Subject: [PATCH] [HACK] efi_runtime: pretend we can't reset
+
+This is a workaround authored mainly for the RK3399 family of hardware.
+
+They *generally* end up using the RK808 PMIC to handle poweroff duties,
+but there's no equivalent feature in U-Boot.
+
+So until U-Boot knows how to poweroff those board, pretend the UEFI
+services can't reset (and poweroff).
+
+Hopefully the operating system will fallback to *any other method* to
+reboot and poweroff. It is known that Linux will.
+---
+ lib/efi_loader/efi_runtime.c | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/lib/efi_loader/efi_runtime.c b/lib/efi_loader/efi_runtime.c
+index 93a695fc27..9a055bb48b 100644
+--- a/lib/efi_loader/efi_runtime.c
++++ b/lib/efi_loader/efi_runtime.c
+@@ -127,13 +127,12 @@ efi_status_t efi_init_runtime_supported(void)
+ 				EFI_RT_SUPPORTED_SET_VIRTUAL_ADDRESS_MAP |
+ 				EFI_RT_SUPPORTED_CONVERT_POINTER;
+ 
+-	/*
+-	 * This value must be synced with efi_runtime_detach_list
+-	 * as well as efi_runtime_services.
++	/* EFI_RT_SUPPORTED_RESET_SYSTEM neutered
++	 * While reset would work, poweroff wouldn't.
++	 * This makes the operating system fall back to the
++	 * default scheme for the target, rather than try UEFI
++	 * poweroff which will only hang the board.
+ 	 */
+-#ifdef CONFIG_EFI_HAVE_RUNTIME_RESET
+-	rt_table->runtime_services_supported |= EFI_RT_SUPPORTED_RESET_SYSTEM;
+-#endif
+ 
+ 	ret = efi_install_configuration_table(&efi_rt_properties_table_guid,
+ 					      rt_table);
+-- 
+2.29.2
+

--- a/support/builders/rockchip-rk3399/default.nix
+++ b/support/builders/rockchip-rk3399/default.nix
@@ -1,7 +1,7 @@
 { buildTowBoot, TF-A, imageBuilder, runCommandNoCC, writeText, spiInstallerPartitionBuilder }:
 
 # For Rockchip RK3399 based hardware
-{ defconfig, postPatch ? "", postInstall ? "", extraConfig ? "", ... } @ args:
+{ defconfig, postPatch ? "", postInstall ? "", extraConfig ? "", patches ? [], ... } @ args:
 
 let
   # Currently 1.1MiB... Let's keep A LOT of room on hand.
@@ -79,7 +79,11 @@ let
       CONFIG_SYS_SPI_U_BOOT_OFFS=0x80000 # 512K
       CONFIG_SPL_DM_SEQ_ALIAS=y
     '' + extraConfig;
-  } // removeAttrs args [ "postPatch" "postInstall" "extraConfig" ]);
+
+    patches = [
+      ./0001-HACK-efi_runtime-pretend-we-can-t-reset.patch
+    ] ++ patches;
+  } // removeAttrs args [ "postPatch" "postInstall" "extraConfig" "patches" ]);
 in
 runCommandNoCC firmware.name { } ''
   mkdir -p "$out"


### PR DESCRIPTION
This is a non-upstreamable workaround.

What we do is pretend this UEFI implementation cannot do things like
reset and poweroff.

In turn, the operating system may fallback to any other method. Which
for Linux is true.

* * *

Reminder that the goal of this project is to make the life of the end-user easier, by providing user experiences fixes. This is a user-experience fix, considering that without this boards hangs.

This is extremely important for the Pinebook Pro, as if powerd-off via UEFI, it will continue chewing through power as it is "stuck" hanging [in the UEFI services](https://source.denx.de/u-boot/u-boot/-/blob/a4262e5506bf967c4ad07f86442c1f461af22283/lib/efi_loader/efi_runtime.c#L215-222).