### PR TITLE
Emit patches for a given Tow-Boot build

### DIFF
--- a/boards/odroid/odroid-c2.nix
+++ b/boards/odroid/odroid-c2.nix
@@ -113,9 +113,6 @@ let
     meta.platforms = ["aarch64-linux"];
   };
 in
-runCommandNoCC firmware.name {} ''
-  mkdir -p "$out"
-  cp -rvt $out/ ${firmware}/.config
-  cp -rvt $out/ ${firmware}/*
+firmware.mkOutput ''
   cp -rv ${baseImage}/*.img $out/disk-image.img
 ''

--- a/boards/raspberryPi/default.nix
+++ b/boards/raspberryPi/default.nix
@@ -107,10 +107,14 @@ in
   raspberryPi-aarch64 = runCommandNoCC "tow-boot-raspberryPi-aarch64-${raspberryPi-3.version}" {} ''
     mkdir -p $out
     (cd $out
+      cp -rv ${raspberryPi-3.patchset} tow-boot-rpi3-patches
       cp -v ${raspberryPi-3}/u-boot.bin tow-boot-rpi3.bin
       cp -v ${raspberryPi-3}/.config .config.tow-boot-rpi3.bin
+
+      cp -rv ${raspberryPi-4.patchset} tow-boot-rpi4-patches
       cp -v ${raspberryPi-4}/u-boot.bin tow-boot-rpi4.bin
       cp -v ${raspberryPi-4}/.config .config.tow-boot-rpi4.bin
+
       cp -v ${baseImage}/*.img $out/disk-image.img
     )
   '';

--- a/support/builders/allwinner-a64/default.nix
+++ b/support/builders/allwinner-a64/default.nix
@@ -39,10 +39,7 @@ let
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   } // args);
 in
-runCommandNoCC firmware.name {} ''
-  mkdir -p "$out"
-  cp -rvt $out/ ${firmware}/.config
-  cp -rvt $out/ ${firmware}/*
+firmware.mkOutput ''
   cp -rv ${baseImage}/*.img $out/disk-image.img
   ${lib.optionalString withSPI ''
   cp -rv ${spiInstallerImage}/*.img $out/spi-installer.img

--- a/support/builders/allwinner-armv7/default.nix
+++ b/support/builders/allwinner-armv7/default.nix
@@ -39,10 +39,7 @@ let
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   } // args);
 in
-runCommandNoCC firmware.name {} ''
-  mkdir -p "$out"
-  cp -rvt $out/ ${firmware}/.config
-  cp -rvt $out/ ${firmware}/*
+firmware.mkOutput ''
   cp -rv ${baseImage}/*.img $out/disk-image.img
   ${lib.optionalString withSPI ''
   cp -rv ${spiInstallerImage}/*.img $out/spi-installer.img

--- a/support/builders/amlogic-gxl/default.nix
+++ b/support/builders/amlogic-gxl/default.nix
@@ -91,10 +91,7 @@ let
     filesToInstall = [ "u-boot.bin" "u-boot.bin.usb.bl2" "u-boot.bin.usb.tpl" ];
   } // args);
 in
-runCommandNoCC firmware.name {} ''
-  mkdir -p "$out"
-  cp -rvt $out/ ${firmware}/.config
-  cp -rvt $out/ ${firmware}/*
+firmware.mkOutput ''
   cp -rv ${baseImage}/*.img $out/disk-image.img
   ${lib.optionalString withSPI ''
   cp -rv ${spiInstallerImage}/*.img $out/spi-installer.img

--- a/support/builders/rockchip-rk3399/default.nix
+++ b/support/builders/rockchip-rk3399/default.nix
@@ -85,10 +85,7 @@ let
     ] ++ patches;
   } // removeAttrs args [ "postPatch" "postInstall" "extraConfig" "patches" ]);
 in
-runCommandNoCC firmware.name { } ''
-  mkdir -p "$out"
-  cp -rvt $out/ ${firmware}/.config
-  cp -rvt $out/ ${firmware}/*
+firmware.mkOutput ''
   cp -rv ${baseImage}/*.img $out/disk-image.img
   cp -rv ${spiInstallerImage}/*.img $out/spi-installer.img
 ''

--- a/support/builders/tow-boot/default.nix
+++ b/support/builders/tow-boot/default.nix
@@ -256,7 +256,7 @@ let
     } // meta;
 
     passthru = {
-      inherit patchset;
+      inherit mkOutput patchset;
     };
 
   } // removeAttrs args [
@@ -266,6 +266,16 @@ let
     "nativeBuildInputs"
     "patches"
   ]);
+
+  mkOutput = commands: runCommandNoCC tow-boot.name { } ''
+    (PS4=" $ "; set -x
+    mkdir -p "$out"
+    cp -rv ${tow-boot.patchset} $out/patches
+    cp -rvt $out/ ${tow-boot}/.config
+    cp -rvt $out/ ${tow-boot}/*
+    ${commands}
+    )
+  '';
 
   patchset = runCommandNoCC "patches-for-${tow-boot.name}" { } ''
     (PS4=" $ "; set -x

--- a/support/builders/tow-boot/default.nix
+++ b/support/builders/tow-boot/default.nix
@@ -255,6 +255,10 @@ let
       maintainers = with maintainers; [ samueldr ];
     } // meta;
 
+    passthru = {
+      inherit patchset;
+    };
+
   } // removeAttrs args [
     "extraConfig"
     "makeFlags"
@@ -262,5 +266,16 @@ let
     "nativeBuildInputs"
     "patches"
   ]);
+
+  patchset = runCommandNoCC "patches-for-${tow-boot.name}" { } ''
+    (PS4=" $ "; set -x
+    mkdir -p $out
+    cd $out
+    ${lib.concatMapStringsSep "\n" (p: "cp ${p} ./${baseNameOf (toString p)}") tow-boot.patches}
+    cat <<EOF > series
+    ${lib.concatMapStringsSep "\n" (p: "${baseNameOf (toString p)}") tow-boot.patches}
+    EOF
+    )
+  '';
 in
   tow-boot

--- a/support/builders/tow-boot/default.nix
+++ b/support/builders/tow-boot/default.nix
@@ -64,201 +64,203 @@ let
     cp ${../../../assets/splash.bmp} $out/logo.bmp
     (cd $out; gzip -9 -k logo.bmp)
   '';
+
+  tow-boot = stdenv.mkDerivation ({
+    pname = "tow-boot-${defconfig}";
+
+    version = "${uBootVersion}-${towBootIdentifier}";
+
+    src = fetchurl {
+      url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${uBootVersion}.tar.bz2";
+      sha256 = "06p1vymf0dl6jc2xy5w7p42mpgppa46lmpm2ishmgsycnldqnhqd";
+    };
+
+    patches = [
+      # Misc patches to upstream
+      ./patches/0001-cmd-Add-pause-command.patch
+      ./patches/0001-cmd-env-Add-indirect-to-indirectly-set-values.patch
+      ./patches/0001-lib-export-vsscanf.patch
+
+      # Misc patches, not upstreamable as-is
+      ./patches/0001-bootmenu-improvements.patch
+      ./patches/0001-Libretech-autoboot-correct-config-naming-only-allow-.patch
+      ./patches/0001-autoboot-Prevent-C-from-affecting-menucmd.patch
+      ./patches/0001-splash-improvements.patch
+      ./patches/0001-drivers-video-Add-dependency-on-GZIP.patch
+
+      # Tow-Boot specific patches, not upstreamable as-is
+      ./patches/0001-pdcurses.patch
+      ./patches/0001-tow-boot-menu.patch
+      ./patches/0001-Tow-Boot-Provide-opinionated-boot-flow.patch
+      ./patches/0001-Tow-Boot-treewide-Identify-as-Tow-Boot.patch
+
+      # Intrusive non-upstreamable workarounds
+      ./patches/0001-HACK-video-sync-dirty.patch
+
+      # Intrusive opinionated patches
+      ./patches/0001-Tow-Boot-sunxi-ignore-mmc_auto-force-SD-then-eMMC.patch
+    ] ++ patches;
+
+    postPatch = ''
+      patchShebangs tools
+      patchShebangs arch/arm/mach-rockchip
+    '';
+
+    nativeBuildInputs = [
+      bc
+      bison
+      dtc
+      flex
+      openssl
+      (buildPackages.python3.withPackages (p: [
+        p.libfdt
+        p.setuptools # for pkg_resources
+      ]))
+      swig
+    ] ++ nativeBuildInputs;
+
+    depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+    hardeningDisable = [ "all" ];
+
+    makeFlags = [
+      "DTC=dtc"
+      "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+    ] ++ lib.optionals withLogo [
+      # Even though the build will actively use the compressed bmp.gz file,
+      # we have to provide the uncompressed file and file name here.
+      "LOGO_BMP=${compressedLogo}/logo.bmp"
+    ] ++ makeFlags
+    ;
+
+    extraConfig =
+      let
+        reset = "\\e[0m";
+        bright = "\\e[1m";
+      in
+    ''
+      # Identity
+      # --------
+
+      CONFIG_IDENT_STRING="${towBootIdentifier}"
+
+      # Behaviour
+      # ---------
+
+      # Boot menu required for the menu (duh)
+      CONFIG_TOW_BOOT_MENU=y
+
+      # Boot menu and default boot configuration
+
+      # Gives *some* time for the user to act.
+      # Though an already-knowledgeable user will know they can use the key
+      # before the message is shown.
+      # Conversely, CTRL+C can cancel the default boot, showing the menu as
+      # expected In reality, this gives us MUCH MORE slop in the time window
+      # than 2 second.
+      CONFIG_BOOTDELAY=2
+
+      # 27 is ESCAPE
+      CONFIG_AUTOBOOT_MENUKEY=27
+
+      # So we'll fake that using CTRL+C is what we want...
+      # It's only a side-effect.
+      CONFIG_AUTOBOOT_PROMPT="${reset}Please press [${bright}ESCAPE${reset}] or [${bright}CTRL+C${reset}] to enter the boot menu."
+
+      # And this ends up causing the menu to be used on ESCAPE (or CTRL+C)
+      CONFIG_AUTOBOOT_USE_MENUKEY=y
+
+      # Additional commands
+      CONFIG_CMD_BDI=y
+      CONFIG_CMD_CLS=y
+
+      ${lib.optionalString withPoweroff ''
+      CONFIG_CMD_POWEROFF=y
+      ''}
+
+      # Looks
+      # -----
+
+      # Ensures white text on black background
+      CONFIG_SYS_WHITE_ON_BLACK=y
+
+      ${lib.optionalString (!withTTF) ''
+      # CONFIG_CONSOLE_TRUETYPE is not set
+      # CONFIG_CONSOLE_TRUETYPE_NIMBUS is not set
+      ''}
+      ${lib.optionalString withTTF ''
+      # Truetype console configuration
+      CONFIG_CONSOLE_TRUETYPE=y
+      CONFIG_CONSOLE_TRUETYPE_NIMBUS=y
+      CONFIG_CONSOLE_TRUETYPE_SIZE=26
+      # Ensure the chosen font is used
+      CONFIG_CONSOLE_TRUETYPE_CANTORAONE=n
+      CONFIG_CONSOLE_TRUETYPE_ANKACODER=n
+      CONFIG_CONSOLE_TRUETYPE_RUFSCRIPT=n
+      ''}
+
+      ${lib.optionalString withLogo ''
+      # For the splash screen
+      CONFIG_CMD_BMP=y
+      CONFIG_SPLASHIMAGE_GUARD=y
+      CONFIG_SPLASH_SCREEN=y
+      CONFIG_SPLASH_SCREEN_ALIGN=y
+      CONFIG_VIDEO_BMP_GZIP=y
+      CONFIG_VIDEO_BMP_LOGO=y
+      CONFIG_VIDEO_BMP_RLE8=n
+      CONFIG_BMP_16BPP=y
+      CONFIG_BMP_24BPP=y
+      CONFIG_BMP_32BPP=y
+      CONFIG_SPLASH_SOURCE=n
+      ''}
+
+      # Additional configuration (if needed)
+      ${extraConfig}
+    '';
+
+    # Inject defines for things lacking actual configuration options.
+    NIX_CFLAGS_COMPILE = lib.optionals withLogo [
+      "-DCONFIG_SYS_VIDEO_LOGO_MAX_SIZE=${toString (1920*1080*4)}"
+      "-DCONFIG_VIDEO_LOGO"
+    ];
+
+    passAsFile = [ "extraConfig" ];
+
+    configurePhase = ''
+      runHook preConfigure
+      make ${defconfig}
+      cat $extraConfigPath >> .config
+      runHook postConfigure
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp .config $out
+      ${lib.optionalString (builtins.length filesToInstall > 0) ''
+      cp ${lib.concatStringsSep " " filesToInstall} $out
+      ''}
+      runHook postInstall
+    '';
+
+    # make[2]: *** No rule to make target 'lib/efi_loader/helloworld.efi', needed by '__build'.  Stop.
+    enableParallelBuilding = false;
+
+    dontStrip = true;
+
+    meta = with lib; {
+      homepage = "https://github.com/Tow-Boot/Tow-Boot";
+      description = "Your boring SBC firmware";
+      license = licenses.gpl2;
+      maintainers = with maintainers; [ samueldr ];
+    } // meta;
+
+  } // removeAttrs args [
+    "extraConfig"
+    "makeFlags"
+    "meta"
+    "nativeBuildInputs"
+    "patches"
+  ]);
 in
-stdenv.mkDerivation ({
-  pname = "tow-boot-${defconfig}";
-
-  version = "${uBootVersion}-${towBootIdentifier}";
-
-  src = fetchurl {
-    url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${uBootVersion}.tar.bz2";
-    sha256 = "06p1vymf0dl6jc2xy5w7p42mpgppa46lmpm2ishmgsycnldqnhqd";
-  };
-
-  patches = [
-    # Misc patches to upstream
-    ./patches/0001-cmd-Add-pause-command.patch
-    ./patches/0001-cmd-env-Add-indirect-to-indirectly-set-values.patch
-    ./patches/0001-lib-export-vsscanf.patch
-
-    # Misc patches, not upstreamable as-is
-    ./patches/0001-bootmenu-improvements.patch
-    ./patches/0001-Libretech-autoboot-correct-config-naming-only-allow-.patch
-    ./patches/0001-autoboot-Prevent-C-from-affecting-menucmd.patch
-    ./patches/0001-splash-improvements.patch
-    ./patches/0001-drivers-video-Add-dependency-on-GZIP.patch
-
-    # Tow-Boot specific patches, not upstreamable as-is
-    ./patches/0001-pdcurses.patch
-    ./patches/0001-tow-boot-menu.patch
-    ./patches/0001-Tow-Boot-Provide-opinionated-boot-flow.patch
-    ./patches/0001-Tow-Boot-treewide-Identify-as-Tow-Boot.patch
-
-    # Intrusive non-upstreamable workarounds
-    ./patches/0001-HACK-video-sync-dirty.patch
-
-    # Intrusive opinionated patches
-    ./patches/0001-Tow-Boot-sunxi-ignore-mmc_auto-force-SD-then-eMMC.patch
-  ] ++ patches;
-
-  postPatch = ''
-    patchShebangs tools
-    patchShebangs arch/arm/mach-rockchip
-  '';
-
-  nativeBuildInputs = [
-    bc
-    bison
-    dtc
-    flex
-    openssl
-    (buildPackages.python3.withPackages (p: [
-      p.libfdt
-      p.setuptools # for pkg_resources
-    ]))
-    swig
-  ] ++ nativeBuildInputs;
-
-  depsBuildBuild = [ buildPackages.stdenv.cc ];
-
-  hardeningDisable = [ "all" ];
-
-  makeFlags = [
-    "DTC=dtc"
-    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
-  ] ++ lib.optionals withLogo [
-    # Even though the build will actively use the compressed bmp.gz file,
-    # we have to provide the uncompressed file and file name here.
-    "LOGO_BMP=${compressedLogo}/logo.bmp"
-  ] ++ makeFlags
-  ;
-
-  extraConfig =
-    let
-      reset = "\\e[0m";
-      bright = "\\e[1m";
-    in
-  ''
-    # Identity
-    # --------
-
-    CONFIG_IDENT_STRING="${towBootIdentifier}"
-
-    # Behaviour
-    # ---------
-
-    # Boot menu required for the menu (duh)
-    CONFIG_TOW_BOOT_MENU=y
-
-    # Boot menu and default boot configuration
-
-    # Gives *some* time for the user to act.
-    # Though an already-knowledgeable user will know they can use the key
-    # before the message is shown.
-    # Conversely, CTRL+C can cancel the default boot, showing the menu as
-    # expected In reality, this gives us MUCH MORE slop in the time window
-    # than 2 second.
-    CONFIG_BOOTDELAY=2
-
-    # 27 is ESCAPE
-    CONFIG_AUTOBOOT_MENUKEY=27
-
-    # So we'll fake that using CTRL+C is what we want...
-    # It's only a side-effect.
-    CONFIG_AUTOBOOT_PROMPT="${reset}Please press [${bright}ESCAPE${reset}] or [${bright}CTRL+C${reset}] to enter the boot menu."
-
-    # And this ends up causing the menu to be used on ESCAPE (or CTRL+C)
-    CONFIG_AUTOBOOT_USE_MENUKEY=y
-
-    # Additional commands
-    CONFIG_CMD_BDI=y
-    CONFIG_CMD_CLS=y
-
-    ${lib.optionalString withPoweroff ''
-    CONFIG_CMD_POWEROFF=y
-    ''}
-
-    # Looks
-    # -----
-
-    # Ensures white text on black background
-    CONFIG_SYS_WHITE_ON_BLACK=y
-
-    ${lib.optionalString (!withTTF) ''
-    # CONFIG_CONSOLE_TRUETYPE is not set
-    # CONFIG_CONSOLE_TRUETYPE_NIMBUS is not set
-    ''}
-    ${lib.optionalString withTTF ''
-    # Truetype console configuration
-    CONFIG_CONSOLE_TRUETYPE=y
-    CONFIG_CONSOLE_TRUETYPE_NIMBUS=y
-    CONFIG_CONSOLE_TRUETYPE_SIZE=26
-    # Ensure the chosen font is used
-    CONFIG_CONSOLE_TRUETYPE_CANTORAONE=n
-    CONFIG_CONSOLE_TRUETYPE_ANKACODER=n
-    CONFIG_CONSOLE_TRUETYPE_RUFSCRIPT=n
-    ''}
-
-    ${lib.optionalString withLogo ''
-    # For the splash screen
-    CONFIG_CMD_BMP=y
-    CONFIG_SPLASHIMAGE_GUARD=y
-    CONFIG_SPLASH_SCREEN=y
-    CONFIG_SPLASH_SCREEN_ALIGN=y
-    CONFIG_VIDEO_BMP_GZIP=y
-    CONFIG_VIDEO_BMP_LOGO=y
-    CONFIG_VIDEO_BMP_RLE8=n
-    CONFIG_BMP_16BPP=y
-    CONFIG_BMP_24BPP=y
-    CONFIG_BMP_32BPP=y
-    CONFIG_SPLASH_SOURCE=n
-    ''}
-
-    # Additional configuration (if needed)
-    ${extraConfig}
-  '';
-
-  # Inject defines for things lacking actual configuration options.
-  NIX_CFLAGS_COMPILE = lib.optionals withLogo [
-    "-DCONFIG_SYS_VIDEO_LOGO_MAX_SIZE=${toString (1920*1080*4)}"
-    "-DCONFIG_VIDEO_LOGO"
-  ];
-
-  passAsFile = [ "extraConfig" ];
-
-  configurePhase = ''
-    runHook preConfigure
-    make ${defconfig}
-    cat $extraConfigPath >> .config
-    runHook postConfigure
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out
-    cp .config $out
-    ${lib.optionalString (builtins.length filesToInstall > 0) ''
-    cp ${lib.concatStringsSep " " filesToInstall} $out
-    ''}
-    runHook postInstall
-  '';
-
-  # make[2]: *** No rule to make target 'lib/efi_loader/helloworld.efi', needed by '__build'.  Stop.
-  enableParallelBuilding = false;
-
-  dontStrip = true;
-
-  meta = with lib; {
-    homepage = "https://github.com/Tow-Boot/Tow-Boot";
-    description = "Your boring SBC firmware";
-    license = licenses.gpl2;
-    maintainers = with maintainers; [ samueldr ];
-  } // meta;
-
-} // removeAttrs args [
-  "extraConfig"
-  "makeFlags"
-  "meta"
-  "nativeBuildInputs"
-  "patches"
-])
+  tow-boot


### PR DESCRIPTION
The outputs, which in turn are used for the release tarballs, now includes a `patches` directory with all the patches applied on top of U-Boot.

Combine this with the fact the `.config` file is available in the root of the tarball, it should be easier for individuals to re-combine a given Tow-Boot release on top of U-Boot without using the tooling here.

Note that this is not meant to replace the tooling. This is mainly to better handle GPL compliance by providing all patches side-by-side with the binaries.