### PR TITLE
Add support for the ODROID N2

### DIFF
--- a/boards/odroid/0001-Enable-the-SPI-on-the-ODROID-N2-by-default.patch
+++ b/boards/odroid/0001-Enable-the-SPI-on-the-ODROID-N2-by-default.patch
@@ -1,0 +1,57 @@
+From 367dfbebd1099f7c3d58ee1da007653f34fb0f69 Mon Sep 17 00:00:00 2001
+From: Las <las@protonmail.ch>
+Date: Wed, 16 Jun 2021 12:28:17 +0000
+Subject: [PATCH] Enable the SPI on the ODROID N2 by default
+
+This halves the the bandwidth to the eMMC, but given
+that this will apparently be restored when booting a kernel with the
+default device tree, it isn't really important.
+---
+ arch/arm/dts/meson-g12b-odroid-n2.dtsi | 6 +++---
+ configs/odroid-n2_defconfig            | 6 ++++++
+ 2 files changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/dts/meson-g12b-odroid-n2.dtsi b/arch/arm/dts/meson-g12b-odroid-n2.dtsi
+index 6982632ae6..ef77b1c77f 100644
+--- a/arch/arm/dts/meson-g12b-odroid-n2.dtsi
++++ b/arch/arm/dts/meson-g12b-odroid-n2.dtsi
+@@ -515,11 +515,11 @@
+ /* eMMC */
+ &sd_emmc_c {
+ 	status = "okay";
+-	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_8b_pins>, <&emmc_ds_pins>;
++	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_4b_pins>, <&emmc_ds_pins>;
+ 	pinctrl-1 = <&emmc_clk_gate_pins>;
+ 	pinctrl-names = "default", "clk-gate";
+ 
+-	bus-width = <8>;
++	bus-width = <4>;
+ 	cap-mmc-highspeed;
+ 	mmc-ddr-1_8v;
+ 	mmc-hs200-1_8v;
+@@ -539,7 +539,7 @@
+  * The SW1 slide should also be set to the correct position.
+  */
+ &spifc {
+-	status = "disabled";
++	status = "okay";
+ 	pinctrl-0 = <&nor_pins>;
+ 	pinctrl-names = "default";
+ 
+diff --git a/configs/odroid-n2_defconfig b/configs/odroid-n2_defconfig
+index 8a12148fb4..d02bae4feb 100644
+--- a/configs/odroid-n2_defconfig
++++ b/configs/odroid-n2_defconfig
+@@ -71,3 +71,9 @@ CONFIG_BMP_16BPP=y
+ CONFIG_BMP_24BPP=y
+ CONFIG_BMP_32BPP=y
+ CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_CMD_SPI=y
++CONFIG_DM_SPI_FLASH=y
++CONFIG_SPI_FLASH_MACRONIX=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MESON_SPIFC=y
+-- 
+2.31.1
+

--- a/boards/odroid/0001-Fix-n2-plus-fdtfile.patch
+++ b/boards/odroid/0001-Fix-n2-plus-fdtfile.patch
@@ -1,0 +1,27 @@
+diff --git a/board/amlogic/odroid-n2/odroid-n2.c b/board/amlogic/odroid-n2/odroid-n2.c
+index 88a60f34fe8c70a8b78c1e54eaa92a66a0dcc8df..acfd107fc544ac0ca8855e65d28dde5183b41090 100644
+--- a/board/amlogic/odroid-n2/odroid-n2.c
++++ b/board/amlogic/odroid-n2/odroid-n2.c
+@@ -48,7 +48,7 @@ static struct meson_odroid_boards {
+ 	/* OdroidN2 rev 2019,2,7 */
+ 	{ MESON_SOC_ID_G12B, 330 * 4, 350 * 4, "n2" },
+ 	/* OdroidN2plus rev 2019,11,20 */
+-	{ MESON_SOC_ID_G12B, 410 * 4, 430 * 4, "n2_plus" },
++	{ MESON_SOC_ID_G12B, 410 * 4, 430 * 4, "n2-plus" },
+ 	/* OdroidC4 rev 2020,01,29 */
+ 	{ MESON_SOC_ID_SM1,   80 * 4, 100 * 4, "c4" },
+ 	/* OdroidHC4 rev 2019,12,10 */
+diff --git a/configs/odroid-n2_defconfig b/configs/odroid-n2_defconfig
+index bac44b61abb86aa27f4595880d556a3df27a227e..1f718a3154ef0736fbb0c280cecb3abbace3d08a 100644
+--- a/configs/odroid-n2_defconfig
++++ b/configs/odroid-n2_defconfig
+@@ -9,7 +9,7 @@ CONFIG_DEFAULT_DEVICE_TREE="meson-g12b-odroid-n2"
+ CONFIG_MESON_G12A=y
+ CONFIG_DEBUG_UART_BASE=0xff803000
+ CONFIG_DEBUG_UART_CLOCK=24000000
+-CONFIG_IDENT_STRING=" odroid-n2/n2_plus"
++CONFIG_IDENT_STRING=" odroid-n2/n2-plus"
+ CONFIG_DEFAULT_DEVICE_TREE="meson-g12b-odroid-n2"
+ CONFIG_DEBUG_UART=y
+ CONFIG_OF_BOARD_SETUP=y
+ # CONFIG_DISPLAY_CPUINFO is not set

--- a/boards/odroid/default.nix
+++ b/boards/odroid/default.nix
@@ -11,6 +11,11 @@
       # ODROID N2 SPI support
       ./0001-Enable-the-SPI-on-the-ODROID-N2-by-default.patch
     ];
+    extraConfig = ''
+      CONFIG_USE_PREBOOT=y
+      CONFIG_PREBOOT="usb start ; usb info"
+    '';
+
   };
   odroid-C2 = Tow-Boot.systems.aarch64.callPackage ./odroid-c2.nix { };
 }

--- a/boards/odroid/default.nix
+++ b/boards/odroid/default.nix
@@ -1,5 +1,18 @@
-{ Tow-Boot }:
+{ Tow-Boot, amlogicG12, amlogicFirmware }:
 
 {
+  odroid-N2 = amlogicG12 {
+    boardIdentifier = "odroid-N2";
+    defconfig = "odroid-n2_defconfig";
+    FIPDIR = "${amlogicFirmware}/odroid-n2";
+    # Access to the SPI flash itself works fine, but the SPI installer menu
+    # doesn't work, shows visual artifacts, and somehow gets stuck in that state.
+    withSPI = false;
+    SPISize = 8 * 1024 * 1024;
+    patches = [
+      # ODROID N2 SPI support
+      ./0001-Enable-the-SPI-on-the-ODROID-N2-by-default.patch
+    ];
+  };
   odroid-C2 = Tow-Boot.systems.aarch64.callPackage ./odroid-c2.nix { };
 }

--- a/boards/odroid/default.nix
+++ b/boards/odroid/default.nix
@@ -10,6 +10,8 @@
     patches = [
       # ODROID N2 SPI support
       ./0001-Enable-the-SPI-on-the-ODROID-N2-by-default.patch
+      # fix DTB file location on N2+. to be removed once we upgrade to U-Boot 2021.10
+      ./0001-Fix-n2-plus-fdtfile.patch
     ];
     extraConfig = ''
       CONFIG_USE_PREBOOT=y

--- a/boards/odroid/default.nix
+++ b/boards/odroid/default.nix
@@ -5,9 +5,7 @@
     boardIdentifier = "odroid-N2";
     defconfig = "odroid-n2_defconfig";
     FIPDIR = "${amlogicFirmware}/odroid-n2";
-    # Access to the SPI flash itself works fine, but the SPI installer menu
-    # doesn't work, shows visual artifacts, and somehow gets stuck in that state.
-    withSPI = false;
+    withSPI = true;
     SPISize = 8 * 1024 * 1024;
     patches = [
       # ODROID N2 SPI support

--- a/support/builders/amlogic-g12/default.nix
+++ b/support/builders/amlogic-g12/default.nix
@@ -45,12 +45,14 @@ let
     ];
 
     postBuild = ''
+      echo " :: Merging with proprietary components..."
+      (PS4=" $ "; set -x
       meson64-pkg --type bl30 --output bl30.pkg $FIPDIR/bl30.bin $FIPDIR/bl301.bin
       meson64-pkg --type bl2 --output bl2.pkg $FIPDIR/bl2.bin $FIPDIR/acs.bin
       meson64-bl30sig --input bl30.pkg --output bl30.30sig
       meson64-bl3sig  --input bl30.30sig --output bl30.3sig
       meson64-bl3sig  --input $FIPDIR/bl31.img --output bl31.3sig
-      meson64-bl3sig  --input Tow-Boot.bin --output bl33.3sig
+      meson64-bl3sig  --input u-boot.bin --output bl33.3sig
       meson64-bl2sig  --input bl2.pkg --output bl2.2sig
       args=(
         --bl2 bl2.2sig
@@ -69,8 +71,8 @@ let
       test -e $FIPDIR/aml_ddr.fw && args+=(--ddrfw8 $FIPDIR/aml_ddr.fw)
       test -e $FIPDIR/lpddr3_1d.fw && args+=(--ddrfw9 $FIPDIR/lpddr3_1d.fw)
 
-      meson64-bootmk --output Tow-Boot2.bin "''${args[@]}"
-      mv Tow-Boot2.bin Tow-Boot.bin
+      meson64-bootmk --output Tow-Boot.bin "''${args[@]}"
+      )
     '';
 
     installPhase = ''

--- a/support/builders/amlogic-g12/default.nix
+++ b/support/builders/amlogic-g12/default.nix
@@ -1,0 +1,94 @@
+{ lib, buildTowBoot, meson64-tools, imageBuilder, runCommandNoCC, spiInstallerPartitionBuilder }:
+
+let self =
+{ FIPDIR, withSPI ? false,  ...} @ args':
+
+let
+  args = removeAttrs args' (builtins.attrNames (builtins.functionArgs self));
+
+  partitionOffset = 1;
+  sectorSize = 512;
+  firmwareMaxSize = imageBuilder.size.MiB 4;
+
+  firmwarePartition = imageBuilder.firmwarePartition {
+    inherit sectorSize;
+    partitionOffset = partitionOffset; # in sectors
+    partitionSize = firmwareMaxSize; # in bytes
+    firmwareFile = "${firmware}/binaries/Tow-Boot.noenv.bin";
+  };
+
+  baseImage' = extraPartitions: imageBuilder.diskImage.makeMBR {
+    name = "disk-image";
+    diskID = "01234567";
+    # Align on 512 sector sizes.
+    # This is not for the actual partitions for the end-user, only so we
+    # are able to make the first partition start at sector 0x01
+    alignment = 512;
+
+    partitions = [
+      firmwarePartition
+    ] ++ extraPartitions;
+  };
+  baseImage = baseImage' [];
+  spiInstallerImage = baseImage' [
+    (spiInstallerPartitionBuilder {
+      firmware = firmwareSPI;
+    })
+  ];
+
+  firmware' = variant: buildTowBoot ({
+    meta.platforms = [ "aarch64-linux" ];
+    inherit variant FIPDIR;
+
+    nativeBuildInputs = [
+      meson64-tools
+    ];
+
+    postBuild = ''
+      meson64-pkg --type bl30 --output bl30.pkg $FIPDIR/bl30.bin $FIPDIR/bl301.bin
+      meson64-pkg --type bl2 --output bl2.pkg $FIPDIR/bl2.bin $FIPDIR/acs.bin
+      meson64-bl30sig --input bl30.pkg --output bl30.30sig
+      meson64-bl3sig  --input bl30.30sig --output bl30.3sig
+      meson64-bl3sig  --input $FIPDIR/bl31.img --output bl31.3sig
+      meson64-bl3sig  --input Tow-Boot.bin --output bl33.3sig
+      meson64-bl2sig  --input bl2.pkg --output bl2.2sig
+      args=(
+        --bl2 bl2.2sig
+        --bl30 bl30.3sig
+        --bl31 bl31.3sig
+        --bl33 bl33.3sig
+
+        --ddrfw1 $FIPDIR/ddr4_1d.fw
+        --ddrfw2 $FIPDIR/ddr4_2d.fw
+        --ddrfw3 $FIPDIR/ddr3_1d.fw
+        --ddrfw4 $FIPDIR/piei.fw
+        --ddrfw5 $FIPDIR/lpddr4_1d.fw
+        --ddrfw6 $FIPDIR/lpddr4_2d.fw
+        --ddrfw7 $FIPDIR/diag_lpddr4.fw
+      )
+      test -e $FIPDIR/aml_ddr.fw && args+=(--ddrfw8 $FIPDIR/aml_ddr.fw)
+      test -e $FIPDIR/lpddr3_1d.fw && args+=(--ddrfw9 $FIPDIR/lpddr3_1d.fw)
+
+      meson64-bootmk --output Tow-Boot2.bin "''${args[@]}"
+      mv Tow-Boot2.bin Tow-Boot.bin
+    '';
+
+    installPhase = ''
+      cp -v Tow-Boot.bin $out/binaries/Tow-Boot.$variant.bin
+    '';
+  } // args);
+
+  firmware = firmware' "noenv";
+  firmwareSPI = firmware' "spi";
+in
+firmware.mkOutput ''
+  cp --no-preserve=mode -rvt $out/ ${firmware}/*
+  ${lib.optionalString withSPI ''
+    cp --no-preserve=mode -rvt $out/ ${firmwareSPI}/*
+  ''}
+  cp -rv ${baseImage}/*.img $out/shared.disk-image.img
+  ${lib.optionalString withSPI ''
+  cp -rv ${spiInstallerImage}/*.img $out/spi.installer.img
+  ''}
+'';
+in self

--- a/support/builders/amlogic-g12/default.nix
+++ b/support/builders/amlogic-g12/default.nix
@@ -1,7 +1,7 @@
 { lib, buildTowBoot, meson64-tools, imageBuilder, runCommandNoCC, spiInstallerPartitionBuilder }:
 
 let self =
-{ FIPDIR, withSPI ? false, extraConfig ? "", ...} @ args':
+{ FIPDIR, withSPI ? false, ...} @ args':
 
 let
   args = removeAttrs args' (builtins.attrNames (builtins.functionArgs self));
@@ -78,10 +78,6 @@ let
     installPhase = ''
       cp -v Tow-Boot.bin $out/binaries/Tow-Boot.$variant.bin
     '';
-
-    extraConfig = ''
-      CONFIG_USE_PREBOOT=y
-    '' + extraConfig;
 
   } // args);
 

--- a/support/builders/amlogic-g12/default.nix
+++ b/support/builders/amlogic-g12/default.nix
@@ -1,7 +1,7 @@
 { lib, buildTowBoot, meson64-tools, imageBuilder, runCommandNoCC, spiInstallerPartitionBuilder }:
 
 let self =
-{ FIPDIR, withSPI ? false,  ...} @ args':
+{ FIPDIR, withSPI ? false, extraConfig ? "", ...} @ args':
 
 let
   args = removeAttrs args' (builtins.attrNames (builtins.functionArgs self));
@@ -78,6 +78,11 @@ let
     installPhase = ''
       cp -v Tow-Boot.bin $out/binaries/Tow-Boot.$variant.bin
     '';
+
+    extraConfig = ''
+      CONFIG_USE_PREBOOT=y
+    '' + extraConfig;
+
   } // args);
 
   firmware = firmware' "noenv";

--- a/support/overlay/meson64-tools/default.nix
+++ b/support/overlay/meson64-tools/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchFromGitHub, buildPackages }:
+
+stdenv.mkDerivation rec {
+  pname = "meson64-tools";
+  version = "unstable-2020-08-03";
+
+  src = fetchFromGitHub {
+    owner = "angerman";
+    repo = pname;
+    rev = "a2d57d11fd8b4242b903c10dca9d25f7f99d8ff0";
+    sha256 = "1487cr7sv34yry8f0chaj6s2g3736dzq0aqw239ahdy30yg7hb2v";
+  };
+
+  buildInputs = with buildPackages; [ openssl bison yacc flex bc python3 ];
+
+  preBuild = ''
+    patchShebangs .
+    substituteInPlace mbedtls/programs/fuzz/Makefile --replace "python2" "python"
+    substituteInPlace mbedtls/tests/Makefile --replace "python2" "python"
+  '';
+
+  # Also prefix tool names since some names are really generic (e.g. `pkg`).
+  # Otherwise something could shadow those generic names in other builds.
+  postInstall = ''
+    (cd $out/bin
+      for bin in *; do
+        ln -s $bin meson64-$bin
+      done
+    )
+  '';
+
+  makeFlags = [ "PREFIX=$(out)/bin" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/angerman/meson64-tools";
+    description = "Tools for Amlogic Meson ARM64 platforms";
+    license = licenses.unfree; # https://github.com/angerman/meson64-tools/issues/2
+    maintainers = with maintainers; [ aarapov ];
+  };
+}

--- a/support/overlay/overlay.nix
+++ b/support/overlay/overlay.nix
@@ -63,6 +63,8 @@ in
 
     gxlimg = callPackage ./gxlimg { };
 
+    meson64-tools = callPackage ./meson64-tools { };
+
     mkScript = file: final.runCommandNoCC "out.scr" {
       nativeBuildInputs = [
         final.buildPackages.ubootTools

--- a/support/overlay/overlay.nix
+++ b/support/overlay/overlay.nix
@@ -88,6 +88,10 @@ in
       inherit (final.Tow-Boot) gxlimg;
     };
 
+    amlogicG12 = aarch64.callPackage ../builders/amlogic-g12 {
+      inherit (final.Tow-Boot) meson64-tools;
+    };
+
     spiInstallerPartitionBuilder = callPackage ../builders/spi-installer { };
 
     imageBuilder = (callPackage ../image-builder {

--- a/support/overlay/overlay.nix
+++ b/support/overlay/overlay.nix
@@ -83,7 +83,7 @@ in
     };
 
     amlogicGXL = aarch64.callPackage ../builders/amlogic-gxl {
-      gxlimg = final.Tow-Boot.gxlimg;
+      inherit (final.Tow-Boot) gxlimg;
     };
 
     spiInstallerPartitionBuilder = callPackage ../builders/spi-installer { };


### PR DESCRIPTION
I've tested this with [nixos.iso_minimal_new_kernel.aarch64-linux](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.iso_minimal_new_kernel.aarch64-linux) and it works fine, except for the fact that u-boot doesn't support writing to the SPI currently.

Like the C2 it needs some special considerations and therefore doesn't have a separate builder.

I haven't removed building the spi-installer.img, since it will likely work in the future, but should I remove it?