### PR TITLE
Rockchip: Use 115200 baud rate

### DIFF
--- a/doc/differences-from-u-boot.md
+++ b/doc/differences-from-u-boot.md
@@ -1,0 +1,25 @@
+Differences from U-Boot
+=======================
+
+Tow-Boot tries to stay in-line with how U-Boot works. This is to make the
+process of changing back and forth less painful, if desired. It also helps with
+upstreaming changes back into U-Boot.
+
+This document lists the breaking changes compared to U-Boot.
+
+* * *
+
+Behaviour
+---------
+
+### Serial is always at 115200
+
+U-Boot uses the vendor's *usual* serial baud rate. This is fine when trying to
+stay compatible with the vendor's ecosystem and usual ways of doing.
+
+This is problematic when working and documenting across different platforms.
+Having the same software act differently because it is booted on a different
+computer may be surprising.
+
+This is why **115200** is the serial baud rate. To date, no platform was found
+to be incompatible with this baud rate.

--- a/doc/serial.md
+++ b/doc/serial.md
@@ -1,0 +1,13 @@
+Serial console
+==============
+
+> **NOTE**: This document is a stub.
+
+All platforms use the 115200 baud rate. Even platforms which generally default
+to another serial baud rate have been configured for homogeneity.
+
+The author personally uses `picocom` to access the serial console.
+
+```
+ $ picocom -b 115200
+```

--- a/support/builders/tow-boot/default.nix
+++ b/support/builders/tow-boot/default.nix
@@ -105,6 +105,20 @@ let
     postPatch = ''
       patchShebangs tools
       patchShebangs arch/arm/mach-rockchip
+
+      echo ':: Patching baud rate'
+      (PS4=" $ "
+      for f in configs/*rk3399* configs/*rk3328*; do
+        (set -x
+        sed -i"" -e 's/CONFIG_BAUDRATE=1500000/CONFIG_BAUDRATE=115200/' "$f"
+        )
+      done
+      for f in arch/arm/dts/*rk3399*.dts* arch/arm/dts/*rk3328*.dts*; do
+        (set -x
+        sed -i"" -e 's/serial2:1500000n8/serial2:15200n8/' "$f"
+        )
+      done
+      )
     '' + postPatch;
 
     nativeBuildInputs = [

--- a/support/builders/tow-boot/default.nix
+++ b/support/builders/tow-boot/default.nix
@@ -36,6 +36,7 @@
   , filesToInstall ? []
   , defconfig
   , patches ? []
+  , postPatch ? ""
   , nativeBuildInputs ? []
   , meta ? {}
 
@@ -104,7 +105,7 @@ let
     postPatch = ''
       patchShebangs tools
       patchShebangs arch/arm/mach-rockchip
-    '';
+    '' + postPatch;
 
     nativeBuildInputs = [
       bc
@@ -265,6 +266,7 @@ let
     "meta"
     "nativeBuildInputs"
     "patches"
+    "postPatch"
   ]);
 
   mkOutput = commands: runCommandNoCC tow-boot.name { } ''


### PR DESCRIPTION
Closes #6 

* * *

This is a somewhat **breaking change**, and a difference compared to:

  - Vendor ecosystem
  - U-Boot detaults (cc #32)

But conversely, this harmonizes our boards. All boards now will use the same exact serial settings.

Additionally, as was discovered, TF-A already sets it to 115200

  -  https://developer.trustedfirmware.org/T762
  -  https://github.com/ARM-software/arm-trusted-firmware/blob/8078b5c5a0c2a47710df96412d88df53486e2b29/plat/rockchip/rk3399/rk3399_def.h#L20

So it's not out of the question to do it here too.

Finally, some distros will assume 115200 on serial for getty by default. This will help in these cases.

* * *

### TODO

Test on:

 - [x] ROC-RK3399-PC
 - [x] Pinebook Pro

Then:

 - [x] Add documentation about that (General gist: `serial.md` title: *Accessing the serial console*)