### PR TITLE
Take control over the environment

### DIFF
--- a/boards/libreComputer/default.nix
+++ b/boards/libreComputer/default.nix
@@ -24,6 +24,7 @@ in
     defconfig = "libretech-ac_defconfig";
     FIPDIR = "${amlogicFirmware}/lafrite";
     withSPI = true;
+    SPISize = 128 /* Mbits */ * 1024 * 1024 / 8; # equiv to 16 MiB
   };
   libreComputer-rocRk3399Pc = rocRk3399Pc {
     defconfig = "roc-pc-rk3399_defconfig";

--- a/boards/libreComputer/default.nix
+++ b/boards/libreComputer/default.nix
@@ -16,6 +16,7 @@ let
       substituteInPlace include/tow-boot_env.h \
         --replace 'setup_leds=echo\0' 'setup_leds=${setup_leds}\0'
     '';
+    SPISize = 128 /* Mbits */ * 1024 * 1024 / 8; # equiv to 16 MiB
   };
 in
 {

--- a/boards/pine64/default.nix
+++ b/boards/pine64/default.nix
@@ -7,6 +7,7 @@
   pine64-pineA64LTS = allwinnerA64 {
     defconfig = "pine64-lts_defconfig";
     withSPI = true;
+    SPISize = 16 * 1024 * 1024; # 16 MiB
     patches = [
       ./0001-configs-pine64-lts-Enable-SPI-flash.patch
     ];

--- a/boards/pine64/default.nix
+++ b/boards/pine64/default.nix
@@ -16,6 +16,7 @@
   pine64-pinebookPro = Tow-Boot.systems.aarch64.callPackage ./pinebook-pro.nix { };
   pine64-rockpro64 = rockchipRK399 {
     defconfig = "rockpro64-rk3399_defconfig";
+    SPISize = 16 * 1024 * 1024; # 16 MiB
     patches = [
       ./0001-rockpro64-rk3399-Configure-SPI-flash-boot-offset.patch
     ];

--- a/boards/pine64/pinebook-pro.nix
+++ b/boards/pine64/pinebook-pro.nix
@@ -12,6 +12,7 @@ let
 in
 rockchipRK399 {
   defconfig = "pinebook-pro-rk3399_defconfig";
+  SPISize = 16 * 1024 * 1024; # 16 MiB
   postPatch =
     let
       setup_leds = "led green:power on; led red:standby on";

--- a/boards/raspberryPi/default.nix
+++ b/boards/raspberryPi/default.nix
@@ -15,8 +15,11 @@ let
   ;
 
   build = args: aarch64.buildTowBoot ({
+    variant = "noenv";
     meta.platforms = ["aarch64-linux"];
-    filesToInstall = ["u-boot.bin"];
+    installPhase = ''
+      cp -v u-boot.bin $out/binaries/Tow-Boot.$variant.bin
+    '';
     patches = [
       ./0001-configs-rpi-allow-for-bigger-kernels.patch
     ];
@@ -31,10 +34,10 @@ let
 
   config = writeText "config.txt" ''
     [pi3]
-    kernel=tow-boot-rpi3.bin
+    kernel=Tow-Boot.noenv.rpi3.bin
 
     [pi4]
-    kernel=tow-boot-rpi4.bin
+    kernel=Tow-Boot.noenv.rpi4.bin
     enable_gic=1
     armstub=armstub8-gic.bin
     disable_overscan=1
@@ -85,8 +88,8 @@ let
     inherit partitionUUID partitionType;
     populateCommands = ''
       cp -v ${config} config.txt
-      cp -v ${raspberryPi-3}/u-boot.bin tow-boot-rpi3.bin
-      cp -v ${raspberryPi-4}/u-boot.bin tow-boot-rpi4.bin
+      cp -v ${raspberryPi-3}/binaries/Tow-Boot.noenv.bin Tow-Boot.noenv.rpi3.bin
+      cp -v ${raspberryPi-4}/binaries/Tow-Boot.noenv.bin Tow-Boot.noenv.rpi4.bin
       cp -v ${raspberrypi-armstubs}/armstub8-gic.bin armstub8-gic.bin
       (
         target="$PWD"
@@ -105,17 +108,19 @@ in
   # -------------
   #
   raspberryPi-aarch64 = runCommandNoCC "tow-boot-raspberryPi-aarch64-${raspberryPi-3.version}" {} ''
-    mkdir -p $out
+    mkdir -p $out/binaries
+    mkdir -p $out/config
+
     (cd $out
       cp -rv ${raspberryPi-3.patchset} tow-boot-rpi3-patches
-      cp -v ${raspberryPi-3}/u-boot.bin tow-boot-rpi3.bin
-      cp -v ${raspberryPi-3}/.config .config.tow-boot-rpi3.bin
+      cp -v ${raspberryPi-3}/binaries/Tow-Boot.noenv.bin $out/binaries/Tow-Boot.noenv.rpi3.bin
+      cp -v ${raspberryPi-3}/config/noenv.config config/noenv.rpi3.config
 
       cp -rv ${raspberryPi-4.patchset} tow-boot-rpi4-patches
-      cp -v ${raspberryPi-4}/u-boot.bin tow-boot-rpi4.bin
-      cp -v ${raspberryPi-4}/.config .config.tow-boot-rpi4.bin
+      cp -v ${raspberryPi-4}/binaries/Tow-Boot.noenv.bin $out/binaries/Tow-Boot.noenv.rpi4.bin
+      cp -v ${raspberryPi-4}/config/noenv.config config/noenv.rpi4.config
 
-      cp -v ${baseImage}/*.img $out/disk-image.img
+      cp -v ${baseImage}/*.img $out/shared.disk-image.img
     )
   '';
 }

--- a/boards/uBoot/default.nix
+++ b/boards/uBoot/default.nix
@@ -14,7 +14,6 @@ in
 
   uBoot-sandbox = buildTowBoot {
     defconfig = "sandbox_defconfig";
-    filesToInstall = ["u-boot" "u-boot.dtb"];
     buildInputs = with nixpkgs; [
       SDL2
       perl
@@ -23,6 +22,15 @@ in
       ./0001-sandbox-Force-window-size.patch
     ];
     internal = true;
+    variant = "noenv";
+
+    # TODO: Add helper bin to start with dtb file
+    installPhase = ''
+      rmdir $out/binaries
+      mkdir -p $out/libexec
+      cp -v u-boot $out/libexec/tow-boot
+      cp -v u-boot.dtb $out/tow-boot.dtb
+    '';
   };
 
   # Virtualization targets
@@ -30,29 +38,37 @@ in
   uBoot-qemuArm = armv7l.buildTowBoot {
     defconfig = "qemu_arm_defconfig";
     meta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot.bin"];
     internal = true;
+    variant = "noenv";
+    installPhase = ''
+      cp -v u-boot.bin $out/binaries/tow-boot.$variant.bin
+    '';
   };
 
   uBoot-qemuArm64 = aarch64.buildTowBoot {
     defconfig = "qemu_arm64_defconfig";
     meta.platforms = ["aarch64-linux"];
-    filesToInstall = ["u-boot.bin"];
     internal = true;
+    variant = "noenv";
+    installPhase = ''
+      cp -v u-boot.bin $out/binaries/tow-boot.$variant.bin
+    '';
   };
 
   uBoot-qemuX86 = i686.buildTowBoot {
     defconfig = "qemu-x86_defconfig";
     meta.platforms = ["i686-linux"];
-    filesToInstall = ["u-boot.rom"];
     withPoweroff = false;
     internal = true;
+    variant = "noenv";
+    installPhase = ''
+      cp -v u-boot.rom $out/binaries/tow-boot.$variant.rom
+    '';
   };
 
   uBoot-qemuX86_64 = x86_64.buildTowBoot {
     defconfig = "qemu-x86_64_defconfig";
     meta.platforms = ["x86_64-linux"];
-    filesToInstall = ["u-boot.rom"];
 
     # Enabling the logo breaks things left and right
     withLogo = false;
@@ -62,6 +78,13 @@ in
     withTTF = false;
     withPoweroff = false;
     internal = true;
+    variant = "noenv";
+    installPhase = ''
+      cp -v u-boot.rom $out/binaries/tow-boot.$variant.rom
+    '';
+    extraConfig = ''
+      CONFIG_SPL_ENV_SUPPORT=y
+    '';
   };
 
   # EFI payloads
@@ -69,16 +92,22 @@ in
   uBoot-efiX86 = i686.buildTowBoot {
     defconfig = "efi-x86_payload32_defconfig";
     meta.platforms = ["i686-linux"];
-    filesToInstall = ["u-boot-payload.efi"];
     withPoweroff = false;
     internal = true;
+    variant = "noenv";
+    installPhase = ''
+      cp -v u-boot-payload.efi $out/binaries/tow-boot.$variant.efi
+    '';
   };
 
   uBoot-efiX86_64 = x86_64.buildTowBoot {
     defconfig = "efi-x86_payload64_defconfig";
     meta.platforms = ["x86_64-linux"];
-    filesToInstall = ["u-boot-payload.efi"];
     withPoweroff = false;
     internal = true;
+    variant = "noenv";
+    installPhase = ''
+      cp -v u-boot-payload.efi $out/binaries/tow-boot.$variant.efi
+    '';
   };
 }

--- a/doc/in-depth/firmware-storage-map.md
+++ b/doc/in-depth/firmware-storage-map.md
@@ -1,0 +1,97 @@
+Firmware storage map
+====================
+
+This document serves to show where things are written to on the different
+backing storage media.
+
+> **NOTE**: While this documents environment with shared storage media, it is
+> not currently supported by any platforms. Though the allowances are put in
+> place to ensure we can in the future.
+
+
+Overview
+--------
+
+Tow-Boot is intended to be installed to either a dedicated storage media (e.g.
+SPI Flash) or as a discrete partition within the shared media.
+
+In either case, the more than strictly the firmware is stored.
+
+The following map serves to represent on most platforms\*. The exact details
+of the map, the size, and where it is stored will differ, but the general
+idea is the same.
+
+> \*: Some platforms, e.g. the Raspberry Pi family of hardware, does not follow
+> this convention.
+
+```
+|             \\             |      //      |      896 KiB      | 128 KiB |
+|-------------//-------------|      \\      | <unused reserved> |   env   |
+|             \\             |      //      |----------- 1 MiB -----------|
+| ( Platform-specific span ) |  ( Unused )  |    ( Tow-Boot specific)     |
+```
+
+This is a simplified overview.
+
+
+The **Platform-specific span** holds the firmware as loaded by the platform's
+Boot ROM. With most platforms, this is a specially formatted header, maybe
+some platform-specific firmware files, which serves to load the SPL, which
+in turn loads the trustzone implementation, then going back to the SPL,
+which finally loads the actual firmware.
+
+In other words, the *Platform-specific span* generally holds the entire
+firmware implementation.
+
+Next is an **Unused** span. This takes the *remainder* of the space. This
+space is *currently unused*, but expect the firmware code to grow and use that
+space.
+
+Finally, the **Tow-Boot specific** span. This span is *reserved* for Tow-Boot
+use. It is found at the very end of the firmware storage media (or the
+partition). This span is further divided. 896KiB have been set aside in case
+it is ever needed. 128 KiB is then used to hold the environment.
+
+Nothing is set in stone. If a platform requires to encroach on the unused
+reserved space, we will change things.
+
+
+### Rockchip (MMC)
+
+On Rockchip platform, using the shared boot media (installed to SD or eMMC),
+the map for the *Platform-specific span* looks like the following:
+
+```
+LBA : 0x00  \\  0x22  //  0x40         // 0x4000           \\ 0x5840         0x6040
+       |----//---|----\\---|-----------\\--|---------------//--|--------------|
+       | [ GPT ] | (empty) | idbloader //  | firmware.itb  \\  |  (reserved)  |
+	   |    \\   |    //   | ============ Firmware partition ================ |
+```
+
+The partition is 12MiB. Though most of what is found before `0x4000` is mostly
+wasted space currently.
+
+The reserved span looks like this:
+
+```
+byte: 0xb08000            0xbe8000  0xc08000
+LBA : 0x5840              0x5f40    0x6040
+       |-----------------------------|
+       |      896 KiB      | 128 KiB |
+       | <unused reserved> |   env   |
+       |----------- 1 MiB -----------|
+       |    ( Tow-Boot specific)     |
+```
+
+The environment is found in `0xbe8000` up to and excluding `0xc08000`
+
+
+Minimum requirements
+--------------------
+
+While the firmware is currently smaller than that, the minimum requirement is
+**4 MiB**. This is the size used by the discrete protective partition. This
+means that there is up to 3 MiB reserved for Tow-Boot and 
+
+Installation on SPI Flash bigger is, obviously, supported. In those cases the
+environment is still at the very end of the storage media.

--- a/doc/variants.md
+++ b/doc/variants.md
@@ -1,0 +1,47 @@
+Variants
+========
+
+ - `noenv` does not save environment anywhere
+ - `spi` saves the environment to the SPI device
+
+
+`noenv`
+-------
+
+Only the built-in environment is used, read-only. In other words, `saveenv`
+does nothing useful.
+
+This variant is to be used with shared firmware storage *retrofitted* with a
+Tow-Boot installation. In other words, in a system that does not provide a
+protective partition for the firmware.
+
+This variant is also used to build the installer images, as it ensures no stray
+environment will change the behaviour of the installer *when booted form the
+embedded Tow-Boot*.
+
+> **NOTE**: This variant is currently used on all shared firwmare storage
+> installations. In other words, using the protective partition does not
+> *currently* grant the ability to save the environment.
+
+
+`spi`
+-----
+
+This variant is to be used on systems with dedicated firmware storage.
+
+
+
+* * *
+
+
+Upcoming changes
+----------------
+
+It is expected that two other types of variants will come in the future. They
+will provide environment facilities for the shared firmware storage
+installations with protective partitions.
+
+One will save the environment at the end of the protective partition.
+
+The other, spcecialized for the Raspberry Pi family of hardware, will save the
+environment as a file on the Tow-Boot firmware partition.

--- a/support/builders/allwinner-a64/default.nix
+++ b/support/builders/allwinner-a64/default.nix
@@ -12,7 +12,7 @@ let
     inherit sectorSize;
     partitionOffset = partitionOffset; # in sectors
     partitionSize = firmwareMaxSize; # in bytes
-    firmwareFile = "${firmware}/u-boot-sunxi-with-spl.bin";
+    firmwareFile = "${firmware}/binaries/Tow-Boot.noenv.bin";
   };
 
   baseImage' = extraPartitions: imageBuilder.diskImage.makeGPT {
@@ -29,19 +29,29 @@ let
   spiInstallerImage = baseImage' [
     (spiInstallerPartitionBuilder {
       inherit defconfig;
-      firmware = "${firmware}/u-boot-sunxi-with-spl.bin";
+      firmware = "${firmwareSPI}/binaries/Tow-Boot.spi.bin";
     })
   ];
 
-  firmware = buildTowBoot ({
+  firmware' = variant: buildTowBoot ({
     meta.platforms = ["aarch64-linux"];
     BL31 = "${TF-A}/bl31.bin";
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    installPhase = ''
+      cp -v u-boot-sunxi-with-spl.bin $out/binaries/Tow-Boot.$variant.bin
+    '';
+    inherit variant;
   } // args);
+
+  firmware = firmware' "noenv";
+  firmwareSPI = firmware' "spi";
 in
 firmware.mkOutput ''
-  cp -rv ${baseImage}/*.img $out/disk-image.img
+  cp --no-preserve=mode -rvt $out/ ${firmware}/*
   ${lib.optionalString withSPI ''
-  cp -rv ${spiInstallerImage}/*.img $out/spi-installer.img
+    cp --no-preserve=mode -rvt $out/ ${firmwareSPI}/*
+  ''}
+  cp -rv ${baseImage}/*.img $out/shared.disk-image.img
+  ${lib.optionalString withSPI ''
+  cp -rv ${spiInstallerImage}/*.img $out/spi.installer.img
   ''}
 ''

--- a/support/builders/tow-boot/default.nix
+++ b/support/builders/tow-boot/default.nix
@@ -39,6 +39,7 @@
   , postPatch ? ""
   , nativeBuildInputs ? []
   , meta ? {}
+  , passthru ? {}
 
   # The following options should only be disabled when it breaks a build.
   , withLogo ? true
@@ -269,8 +270,11 @@ let
       maintainers = with maintainers; [ samueldr ];
     } // meta;
 
-    passthru = {
-      inherit mkOutput patchset;
+    passthru = passthru // {
+      inherit
+        mkOutput
+        patchset
+      ;
     };
 
   } // removeAttrs args [
@@ -280,6 +284,7 @@ let
     "nativeBuildInputs"
     "patches"
     "postPatch"
+    "passthru"
   ]);
 
   mkOutput = commands: runCommandNoCC tow-boot.name { } ''

--- a/support/builders/tow-boot/default.nix
+++ b/support/builders/tow-boot/default.nix
@@ -258,8 +258,7 @@ let
       runHook postInstall
     '';
 
-    # make[2]: *** No rule to make target 'lib/efi_loader/helloworld.efi', needed by '__build'.  Stop.
-    enableParallelBuilding = false;
+    enableParallelBuilding = true;
 
     dontStrip = true;
 


### PR DESCRIPTION
This is a weird name. But saying it "fixes `saveenv` issues" is too diminutive. But hey, closes #19!

* * *

## What this changes

### Environment

Two broad strokes. For release `002` of Tow-Boot, we will **only** support environment in the SPI Flash for builds installed to the SPI Flash.

Firmware installed to a shared storage media, starting with `002` up to later will not allow saving the environment.

To reduce confusion, a Tow-Boot install will **strictly** only use the environment in the same storage it is installed into. This means that SPI-installed firmware will read/save to the SPI Flash. Not implemented yet, but using the shared storage strategy, **only when installed to a protective partition** will Tow-Boot read/save the environment.

### Variants

Since we need to change how the firmware acts depending on where it is installed, it was deemed the easiest method to *just* build different binaries. So we're now producing "variants", which in turn affect the configuration slightly. These are somewhat different from "simple" feature flags, as we are changing a fundamental property of the firmware.

It's not expected we'll gain many more variants. In fact the only one I expect to add is `mmc` which (using the U-Boot nomenclature) will use the partition from the shared storage media to manage the environment.

In other words, variants right now are strictly dealing with where the environment is read and saved.

### File names and structure

It was coming, but since we needed to change file names for variants, I'm implementing the changes here. All files now report as "Tow-Boot". It apparently caused mild confusion in some users that the files were named "u-boot". Additionally, files are now stored in directories, `config` for the variant configuraiotns, and `binaries` for the "irrlevant to most users" files.

The main stars, the disk images, are at the root of the result.

* * *

## Future changes

### Environment with shared storage

As stated previously "**only when installed to a protective partition** will Tow-Boot read/save the environment."

This requires some development. There are no environment saving strategies that allows this to work in a safe manner.

Since we want to save to the same partition Tow-Boot is installed into, we need the environment "in MMC". With that strategy, *only* an offset to a *hardcoded* mmc device is supported. This means that using Tow-Boot on an SD card would save the environment to an arbitrary offset on the internal MMC storage, which **is likely to break things**! So we'll need to track the mmc device the system booted from. Additionally, it would be better if we'd instead be able to work with partitions, and offsets internal to the partition, instead of raw device offsets. This way it is more likely we don't need to implement platform-specific differences.

Using the "in FAT" strategy for the Raspberry Pi family of hardware might work... Except that it is unclear what happens when booting from USB. It will require extensive testing.