### PR TITLE
raspberryPi-*: Increase malloc pool to 64 MiB (+env)

### DIFF
--- a/boards/raspberryPi/0001-Tow-Boot-rpi-Increase-malloc-pool-up-to-64MiB-env.patch
+++ b/boards/raspberryPi/0001-Tow-Boot-rpi-Increase-malloc-pool-up-to-64MiB-env.patch
@@ -1,0 +1,26 @@
+From 82bed57bc6a899a49ea966ce48e5f357ccc00e4d Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Sat, 26 Jun 2021 01:22:25 -0400
+Subject: [PATCH] [Tow-Boot] rpi: Increase malloc pool up to 64MiB (+env)
+
+---
+ include/configs/rpi.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/include/configs/rpi.h b/include/configs/rpi.h
+index 834f1cd236..f7417123c9 100644
+--- a/include/configs/rpi.h
++++ b/include/configs/rpi.h
+@@ -54,7 +54,8 @@
+ #define CONFIG_SYS_INIT_SP_ADDR		(CONFIG_SYS_SDRAM_BASE + \
+ 					 CONFIG_SYS_SDRAM_SIZE - \
+ 					 GENERATED_GBL_DATA_SIZE)
+-#define CONFIG_SYS_MALLOC_LEN		SZ_4M
++/* 64MB of malloc() pool */
++#define CONFIG_SYS_MALLOC_LEN		(CONFIG_ENV_SIZE + (64 << 20))
+ #define CONFIG_LOADADDR			0x00200000
+ 
+ #ifdef CONFIG_ARM64
+-- 
+2.29.2
+

--- a/boards/raspberryPi/default.nix
+++ b/boards/raspberryPi/default.nix
@@ -22,6 +22,7 @@ let
     '';
     patches = [
       ./0001-configs-rpi-allow-for-bigger-kernels.patch
+      ./0001-Tow-Boot-rpi-Increase-malloc-pool-up-to-64MiB-env.patch
     ];
     # The necessary implementation is not provided by U-Boot.
     withPoweroff = false;


### PR DESCRIPTION
This fixes the issue where the logo wouldn't show on the Raspberry Pi family of hardware.

* * *

This is not really an upstreamable change. Really this probably shouldn't be hardcoded per platform in header files, but rather some `Kconfig` option?