### PR TITLE
Improve SPI Flashing

### DIFF
--- a/boards/libreComputer/default.nix
+++ b/boards/libreComputer/default.nix
@@ -3,6 +3,9 @@
 let
   # Re-used for two boards.
   rocRk3399Pc = { defconfig }: rockchipRK399 {
+    # Switching between board with and without mezzanine is permitted.
+    # It is the same board, with a different accessory.
+    boardIdentifier = "libreComputer-rocRk3399Pc";
     inherit defconfig;
     patches = [
       ./0001-rk3399-roc-pc-Configure-SPI-flash-boot-offset.patch
@@ -21,6 +24,7 @@ let
 in
 {
   libreComputer-amlS805xAc = amlogicGXL {
+    boardIdentifier = "libreComputer-amlS805xAc";
     defconfig = "libretech-ac_defconfig";
     FIPDIR = "${amlogicFirmware}/lafrite";
     withSPI = true;

--- a/boards/odroid/odroid-c2.nix
+++ b/boards/odroid/odroid-c2.nix
@@ -50,6 +50,7 @@ let
   };
 
   firmware = buildTowBoot {
+    boardIdentifier = "odroid-C2";
     # Amlogic S905 / GXBB
     # This uses a bespoke build because while it's GXBB, the binaries from the
     # vendor are not as expected.

--- a/boards/olimex/default.nix
+++ b/boards/olimex/default.nix
@@ -1,5 +1,8 @@
 { Tow-Boot, allwinnerA64 }:
 
 {
-  olimex-teresI = allwinnerA64 { defconfig = "teres_i_defconfig"; };
+  olimex-teresI = allwinnerA64 {
+    boardIdentifier = "olimex-teresI";
+    defconfig = "teres_i_defconfig";
+  };
 }

--- a/boards/orangePi/default.nix
+++ b/boards/orangePi/default.nix
@@ -2,9 +2,11 @@
 
 {
   orangePi-pc = allwinnerArmv7 {
+    boardIdentifier = "orangePi-pc";
     defconfig = "orangepi_pc_defconfig";
   };
   orangePi-zeroPlus2H5 = allwinnerA64 {
+    boardIdentifier = "orangePi-zeroPlus2H5";
     defconfig = "orangepi_zero_plus2_defconfig";
     patches = [
       ./0001-sun50i-h5-orangepi-zero-plus2-Enable-USB.patch

--- a/boards/pine64/default.nix
+++ b/boards/pine64/default.nix
@@ -2,9 +2,11 @@
 
 {
   pine64-pineA64 = allwinnerA64 {
+    boardIdentifier = "pine64-pineA64";
     defconfig = "pine64_plus_defconfig";
   };
   pine64-pineA64LTS = allwinnerA64 {
+    boardIdentifier = "pine64-pineA64LTS";
     defconfig = "pine64-lts_defconfig";
     withSPI = true;
     SPISize = 16 * 1024 * 1024; # 16 MiB
@@ -12,13 +14,18 @@
       ./0001-configs-pine64-lts-Enable-SPI-flash.patch
     ];
   };
-  pine64-pinebookA64 = allwinnerA64 { defconfig = "pinebook_defconfig"; };
-  pine64-pinebookPro = Tow-Boot.systems.aarch64.callPackage ./pinebook-pro.nix { };
+  pine64-pinebookA64 = allwinnerA64 {
+    boardIdentifier = "pine64-pinebookA64";
+    defconfig = "pinebook_defconfig";
+  };
   pine64-rockpro64 = rockchipRK399 {
+    boardIdentifier = "pine64-rockpro64";
     defconfig = "rockpro64-rk3399_defconfig";
     SPISize = 16 * 1024 * 1024; # 16 MiB
     patches = [
       ./0001-rockpro64-rk3399-Configure-SPI-flash-boot-offset.patch
     ];
   };
+
+  pine64-pinebookPro = Tow-Boot.systems.aarch64.callPackage ./pinebook-pro.nix { };
 }

--- a/boards/pine64/pinebook-pro.nix
+++ b/boards/pine64/pinebook-pro.nix
@@ -11,6 +11,7 @@ let
   });
 in
 rockchipRK399 {
+  boardIdentifier = "pine64-pinebookPro";
   defconfig = "pinebook-pro-rk3399_defconfig";
   SPISize = 16 * 1024 * 1024; # 16 MiB
   postPatch =

--- a/boards/raspberryPi/default.nix
+++ b/boards/raspberryPi/default.nix
@@ -30,8 +30,14 @@ let
     withTTF = false;
   } // args);
 
-  raspberryPi-3 = build { defconfig = "rpi_3_defconfig"; };
-  raspberryPi-4 = build { defconfig = "rpi_4_defconfig"; };
+  raspberryPi-3 = build {
+    boardIdentifier = "raspberryPi-3";
+    defconfig = "rpi_3_defconfig";
+  };
+  raspberryPi-4 = build {
+    boardIdentifier = "raspberryPi-4";
+    defconfig = "rpi_4_defconfig";
+  };
 
   config = writeText "config.txt" ''
     [pi3]

--- a/boards/uBoot/default.nix
+++ b/boards/uBoot/default.nix
@@ -13,6 +13,7 @@ in
   # Sandbox
 
   uBoot-sandbox = buildTowBoot {
+    boardIdentifier = "uBoot-sandbox";
     defconfig = "sandbox_defconfig";
     buildInputs = with nixpkgs; [
       SDL2
@@ -36,6 +37,7 @@ in
   # Virtualization targets
 
   uBoot-qemuArm = armv7l.buildTowBoot {
+    boardIdentifier = "uBoot-qemuArm";
     defconfig = "qemu_arm_defconfig";
     meta.platforms = ["armv7l-linux"];
     internal = true;
@@ -46,6 +48,7 @@ in
   };
 
   uBoot-qemuArm64 = aarch64.buildTowBoot {
+    boardIdentifier = "uBoot-qemuArm64";
     defconfig = "qemu_arm64_defconfig";
     meta.platforms = ["aarch64-linux"];
     internal = true;
@@ -56,6 +59,7 @@ in
   };
 
   uBoot-qemuX86 = i686.buildTowBoot {
+    boardIdentifier = "uBoot-qemuX86";
     defconfig = "qemu-x86_defconfig";
     meta.platforms = ["i686-linux"];
     withPoweroff = false;
@@ -67,6 +71,7 @@ in
   };
 
   uBoot-qemuX86_64 = x86_64.buildTowBoot {
+    boardIdentifier = "uBoot-qemuX86_64";
     defconfig = "qemu-x86_64_defconfig";
     meta.platforms = ["x86_64-linux"];
 
@@ -90,6 +95,7 @@ in
   # EFI payloads
 
   uBoot-efiX86 = i686.buildTowBoot {
+    boardIdentifier = "uBoot-efiX86";
     defconfig = "efi-x86_payload32_defconfig";
     meta.platforms = ["i686-linux"];
     withPoweroff = false;
@@ -101,6 +107,7 @@ in
   };
 
   uBoot-efiX86_64 = x86_64.buildTowBoot {
+    boardIdentifier = "uBoot-efiX86_64";
     defconfig = "efi-x86_payload64_defconfig";
     meta.platforms = ["x86_64-linux"];
     withPoweroff = false;

--- a/support/builders/allwinner-a64/default.nix
+++ b/support/builders/allwinner-a64/default.nix
@@ -1,7 +1,7 @@
 { lib, buildTowBoot, TF-A, imageBuilder, runCommandNoCC, spiInstallerPartitionBuilder }:
 
 # For Allwinner A64 and Allwinner A64 compatible based hardware
-{ defconfig, withSPI ? false, ... } @ args:
+{ withSPI ? false, ... } @ args:
 
 let
   sectorSize = 512;
@@ -28,8 +28,7 @@ let
   baseImage = baseImage' [];
   spiInstallerImage = baseImage' [
     (spiInstallerPartitionBuilder {
-      inherit defconfig;
-      firmware = "${firmwareSPI}/binaries/Tow-Boot.spi.bin";
+      firmware = firmwareSPI;
     })
   ];
 

--- a/support/builders/allwinner-armv7/default.nix
+++ b/support/builders/allwinner-armv7/default.nix
@@ -1,7 +1,7 @@
 { lib, buildTowBoot, imageBuilder, runCommandNoCC, spiInstallerPartitionBuilder }:
 
 # For armv7 Allwinner boards
-{ defconfig, withSPI ? false, ... } @ args:
+{ withSPI ? false, ... } @ args:
 
 let
   sectorSize = 512;
@@ -28,8 +28,7 @@ let
   baseImage = baseImage' [];
   spiInstallerImage = baseImage' [
     (spiInstallerPartitionBuilder {
-      inherit defconfig;
-      firmware = "${firmwareSPI}/binaries/Tow-Boot.spi.bin";
+      firmware = firmwareSPI;
     })
   ];
 

--- a/support/builders/amlogic-gxl/default.nix
+++ b/support/builders/amlogic-gxl/default.nix
@@ -1,7 +1,7 @@
 { lib, buildTowBoot, gxlimg, imageBuilder, runCommandNoCC, spiInstallerPartitionBuilder }:
 
 # Recognizable by the use of `aml_encrypt_gxl`
-{ defconfig, FIPDIR, postPatch ? "", postInstall ? "", withSPI ? false, ... } @ args:
+{ FIPDIR, postPatch ? "", postInstall ? "", withSPI ? false, ... } @ args:
 
 let
   partitionOffset = 1;
@@ -31,8 +31,7 @@ let
   baseImage = baseImage' [];
   spiInstallerImage = baseImage' [
     (spiInstallerPartitionBuilder {
-      inherit defconfig;
-      firmware = "${firmwareSPI}/binaries/Tow-Boot.spi.bin";
+      firmware = firmwareSPI;
     })
   ];
 

--- a/support/builders/rockchip-rk3399/default.nix
+++ b/support/builders/rockchip-rk3399/default.nix
@@ -1,7 +1,7 @@
 { lib, buildTowBoot, TF-A, imageBuilder, runCommandNoCC, writeText, spiInstallerPartitionBuilder }:
 
 # For Rockchip RK3399 based hardware
-{ defconfig, postPatch ? "", postInstall ? "", extraConfig ? "", patches ? [], withSPI ? true, ... } @ args:
+{ postPatch ? "", postInstall ? "", extraConfig ? "", patches ? [], withSPI ? true, ... } @ args:
 
 let
   # Currently 1.1MiB... Let's keep A LOT of room on hand.
@@ -29,8 +29,7 @@ let
   baseImage = baseImage' [];
   spiInstallerImage = baseImage' [
     (spiInstallerPartitionBuilder {
-      inherit defconfig;
-      firmware = "${firmwareSPI}/binaries/Tow-Boot.spi.bin";
+      firmware = firmwareSPI;
     })
   ];
 
@@ -40,7 +39,6 @@ let
     # Does not actually turn off tested boards...
     withPoweroff = false;
 
-    inherit defconfig;
     inherit
       sectorSize
       partitionOffset

--- a/support/builders/spi-installer/default.nix
+++ b/support/builders/spi-installer/default.nix
@@ -155,7 +155,7 @@ let
     echo
 
     # Commands used by either menu systems, or manually.
-    setenv spi_erase 'sf probe; echo "Currently erasing..."; sf erase 0 +1000000; echo "Done!"; sleep 5'
+    setenv spi_erase 'sf probe; echo "Currently erasing..."; sf erase 0 0x${lib.toHexString SPISize}; echo "Done!"; sleep 5'
     setenv spi_flash 'setenv script flash.scr; run boot_a_script'
 
     setenv bootmenu_0 'Flash firmware to SPI=run spi_flash'

--- a/support/builders/spi-installer/default.nix
+++ b/support/builders/spi-installer/default.nix
@@ -1,7 +1,6 @@
 { lib, writeText, imageBuilder, mkScript }:
 
 { firmware # Firmware derivation
-, flashOffset ? 0
 }:
 
 let
@@ -42,6 +41,12 @@ let
       echo "The board detected is:     "[$board_identifier]
       ''}
     else
+      # Some variables we will be using
+      # (Useless use of setexpr, but eh)
+      setexpr new_firmware_addr_r $kernel_addr_r + 0
+      setexpr old_firmware_addr_r $ramdisk_addr_r + 0
+      setexpr new_firmware_addr_r_tail $new_firmware_addr_r + 0x2000
+
       echo "devtype = $devtype"
       echo "devnum = $devnum"
       part list $devtype $devnum -bootable bootpart
@@ -55,34 +60,70 @@ let
 
         echo ""
         echo "-> Reading Flash content..."
-        if sf read $ramdisk_addr_r 0 0x${lib.toHexString SPISize}; then
+        if sf read $old_firmware_addr_r 0 0x${lib.toHexString SPISize}; then
 
           echo ""
           echo "-> Reading new firmware from storage..."
-          if load $devtype $devnum:$bootpart $kernel_addr_r Tow-Boot.spi.bin; then
+          if load $devtype $devnum:$bootpart $new_firmware_addr_r Tow-Boot.spi.bin; then
+            setexpr new_firmware_size $filesize + 0
+            setexpr new_firmware_size_tail $filesize - 0x2000
 
             echo ""
-            echo "-> Writing new firmware to SPI Flash..."
+            echo "-> Hardening against failures..."
+            echo "   We are deliberately breaking the initial part of the SPI Flash contents."
+            # Safe only if the Boot ROM can read from alternate sources!!
 
-            if sf update $kernel_addr_r ${toString flashOffset} $filesize; then
+            # Erasing the first 8KiB of the SPI Flash
+            # With all tested devices, the Boot ROM will not use the SPI Flash.
+            # This helps ensure a failure in the following steps does not brick the device.
+            if sf erase 0x0 0x2000; then
               echo ""
-              echo "✅ Flashing seems to have been successful!"
+              echo "   A stray reboot should be safe now."
+
               echo ""
-              if pause 'Press any key to reboot...'; then
-                echo -n
+              echo "-> Writing new firmware tail to SPI Flash..."
+              if sf update $new_firmware_addr_r_tail 0x2000 $new_firmware_size_tail; then
+
+                echo ""
+                echo "-> Writing new firmware head to SPI Flash..."
+                if sf update $new_firmware_addr_r 0x0 0x2000; then
+
+                  echo ""
+                  echo "✅ Flashing seems to have been successful!"
+                  echo ""
+                  if pause 'Press any key to reboot...'; then
+                    echo -n
+                  else
+                    echo "Resetting in 5 seconds"
+                    sleep 5
+                  fi
+                  reset
+
+                # sf update head
+                else
+                  ${error ''
+                  echo "❌ Error flashing new firmware head to SPI Flash."
+                  echo "   Rebooting now may fail."
+                  ''}
+                fi
+
+              # sf update tail
               else
-                echo "Resetting in 5 seconds"
-                sleep 5
+                ${error ''
+                echo "⚠️ Error flashing new firmware tail to SPI Flash."
+                echo "  Rebooting now should be safe as the SPI was removed from the boot chain."
+                ''}
               fi
-              reset
 
+            # sf erase 0x2000
             else
               ${error ''
-              echo "❌ Error flashing new firmware to SPI Flash."
-              echo "   Rebooting now may fail."
+              echo "❌ Failed to harden against failures."
+              echo "   If is unknown whether rebooting is safe or not right now."
               ''}
             fi
 
+          # load Tow-Boot.spi.bin
           else
             ${error ''
             echo "⚠️ Error reading new firmware from storage."
@@ -90,6 +131,7 @@ let
             ''}
           fi
 
+        # sf read
         else
           ${error ''
           echo "⚠️ Error reading current firmware."
@@ -97,6 +139,7 @@ let
           ''}
         fi
 
+      # sf probe
       else
         ${error ''
         echo "⚠️ Running `sf probe` failed unexpectedly."
@@ -112,7 +155,7 @@ let
     echo
 
     # Commands used by either menu systems, or manually.
-    setenv spi_erase 'sf probe; echo "Currently erasing..."; sf erase ${toString flashOffset} +1000000; echo "Done!"; sleep 5'
+    setenv spi_erase 'sf probe; echo "Currently erasing..."; sf erase 0 +1000000; echo "Done!"; sleep 5'
     setenv spi_flash 'setenv script flash.scr; run boot_a_script'
 
     setenv bootmenu_0 'Flash firmware to SPI=run spi_flash'

--- a/support/builders/tow-boot/default.nix
+++ b/support/builders/tow-boot/default.nix
@@ -34,6 +34,7 @@
   , makeFlags ? []
 
   , filesToInstall ? []
+  , boardIdentifier
   , defconfig
   , patches ? []
   , postPatch ? ""
@@ -149,6 +150,9 @@ let
         )
       done
       )
+
+      substituteInPlace include/tow-boot_env.h \
+        --replace "@boardIdentifier@" "${boardIdentifier}"
     '' + postPatch;
 
     nativeBuildInputs = [

--- a/support/builders/tow-boot/default.nix
+++ b/support/builders/tow-boot/default.nix
@@ -222,6 +222,7 @@ let
       # Additional commands
       CONFIG_CMD_BDI=y
       CONFIG_CMD_CLS=y
+      CONFIG_CMD_SETEXPR=y
 
       ${lib.optionalString withPoweroff ''
       CONFIG_CMD_POWEROFF=y

--- a/support/builders/tow-boot/default.nix
+++ b/support/builders/tow-boot/default.nix
@@ -357,6 +357,7 @@ let
         mkOutput
         patchset
         variant
+        SPISize
       ;
     };
 

--- a/support/builders/tow-boot/patches/0001-Tow-Boot-Provide-opinionated-boot-flow.patch
+++ b/support/builders/tow-boot/patches/0001-Tow-Boot-Provide-opinionated-boot-flow.patch
@@ -1,14 +1,14 @@
-From a75e5a7bca86d2f89c3267542f37825284292d20 Mon Sep 17 00:00:00 2001
+From 980280024530fbae5b26ffa50e0eebbe083fb939 Mon Sep 17 00:00:00 2001
 From: Samuel Dionne-Riel <samuel@dionne-riel.com>
 Date: Fri, 9 Apr 2021 17:38:16 -0400
-Subject: [PATCH] [Tow-Boot] Provide opinionated boot flow
+Subject: [PATCH] Provide opinionated boot flow
 
 It would be preferrable to read linux,default-trigger or u-boot,default-trigger
 instead of adding `setup_leds` to the env.
 ---
  include/config_distro_bootcmd.h |  6 +++-
- include/tow-boot_env.h          | 54 +++++++++++++++++++++++++++++++++
- 2 files changed, 59 insertions(+), 1 deletion(-)
+ include/tow-boot_env.h          | 57 +++++++++++++++++++++++++++++++++
+ 2 files changed, 62 insertions(+), 1 deletion(-)
  create mode 100644 include/tow-boot_env.h
 
 diff --git a/include/config_distro_bootcmd.h b/include/config_distro_bootcmd.h
@@ -37,10 +37,10 @@ index 2627c2a6a5..3ead5ecf68 100644
  #define CONFIG_BOOTCOMMAND "run distro_bootcmd"
 diff --git a/include/tow-boot_env.h b/include/tow-boot_env.h
 new file mode 100644
-index 0000000000..03e0d4e927
+index 0000000000..284667ab8e
 --- /dev/null
 +++ b/include/tow-boot_env.h
-@@ -0,0 +1,54 @@
+@@ -0,0 +1,57 @@
 +#ifndef _TOW_BOOT_ENV_H
 +#define _TOW_BOOT_ENV_H
 +
@@ -57,6 +57,9 @@ index 0000000000..03e0d4e927
 +#endif
 +
 +#define TOW_BOOT_ENV \
++	/* Used internally to check updater runs on the right board. */ \
++	"board_identifier=@boardIdentifier@\0" \
++	\
 +	/* By default, no setup for LEDs */ \
 +	"setup_leds=echo\0" \
 +	"bootcmd=run setup_leds; run distro_bootcmd\0" \


### PR DESCRIPTION
This brings some changes to the way SPI flashing is done.

### Prevent flashing to the wrong board

(Fixes #3)

In this somewhat breaking change, the script will fail if the `$board_identifier` variable doesn't match a build-time hardcoded constant. This constant is coincidentally the identifier used in the attrset for the board. Though it could have been different if we desired so. The main thing to know is that this identifier will stay the same for the same board, allowing scripts to distinguish between boards.

#### Flashing anyway

The easiest method is to drop to the shell (using ESC or CTRL-C during boot) and using `env set board_identifier XYZ` where `XYZ` is the name of the board you want to flash to.

#### Saved environment missing `$board_identifier`

While unlikely as the last stable version did not manage environment, and this will land on the same release as #34, here's the problem.

You might have a saved environment without `$board_identifier` set. The fix is simple, use `env default board_identifier` to reset that specific variable, and ~~`env save`~~ to save the environment.

### Hardened flashing scheme

(Fixes #28)

The idea is to first *brick* the SPI-installed firmware in a way the Boot ROM will not recognize. This means that if the installation is failing in an uncontrolled manner, the user should be able to recover using an alternate boot method (e.g. SD card or eMMC).

Then, after bricking, flash almost all of the new firmware. *Then* flash the missing bit.

By writing the "magic number" the Boot ROM looks for last, we harden ourselves from accidental partial writes. E.g. if there was sudden power loss.