### PR TITLE
Add support for Radxa RockPi4C

### DIFF
--- a/boards/radxa/0001-rockpi4-rk3399-add-spi-support.patch
+++ b/boards/radxa/0001-rockpi4-rk3399-add-spi-support.patch
@@ -1,0 +1,135 @@
+diff --git a/arch/arm/dts/rk3399-rock-pi-4-u-boot.dtsi b/arch/arm/dts/rk3399-rock-pi-4-u-boot.dtsi
+index c17e769f64..97a5be3dc1 100644
+--- a/arch/arm/dts/rk3399-rock-pi-4-u-boot.dtsi
++++ b/arch/arm/dts/rk3399-rock-pi-4-u-boot.dtsi
+@@ -8,7 +8,27 @@
+ 
+ / {
+ 	chosen {
+-		u-boot,spl-boot-order = "same-as-spl", &sdhci, &sdmmc;
++		u-boot,spl-boot-order = "same-as-spl", &spi_flash, &sdmmc, &sdhci;
++	};
++
++	config {
++		u-boot,spl-payload-offset = <0x80000>;
++	};
++};
++
++&spi1 {
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <10000000>;
++	};
++};
++
++&spi1 {
++	spi_flash: flash@0 {
++		u-boot,dm-pre-reloc;
+ 	};
+ };
+ 
+diff --git a/configs/rock-pi-4-rk3399_defconfig b/configs/rock-pi-4-rk3399_defconfig
+index c7e1a8d2e4..98b37bd426 100644
+--- a/configs/rock-pi-4-rk3399_defconfig
++++ b/configs/rock-pi-4-rk3399_defconfig
+@@ -7,6 +7,8 @@ CONFIG_ROCKCHIP_RK3399=y
+ CONFIG_TARGET_EVB_RK3399=y
+ CONFIG_DEBUG_UART_BASE=0xFF1A0000
+ CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_SPL_SPI_FLASH_SUPPORT=y
++CONFIG_SPL_SPI_SUPPORT=y
+ CONFIG_DEFAULT_DEVICE_TREE="rk3399-rock-pi-4b"
+ CONFIG_DEBUG_UART=y
+ # CONFIG_ANDROID_BOOT_IMAGE is not set
+@@ -16,6 +18,7 @@ CONFIG_MISC_INIT_R=y
+ # CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
+ CONFIG_SPL_STACK_R=y
+ CONFIG_SPL_STACK_R_MALLOC_SIMPLE_LEN=0x10000
++CONFIG_SPL_SPI_LOAD=y
+ CONFIG_TPL=y
+ CONFIG_CMD_BOOTZ=y
+ CONFIG_CMD_GPT=y
+@@ -26,8 +29,9 @@ CONFIG_CMD_USB=y
+ CONFIG_CMD_TIME=y
+ CONFIG_SPL_OF_CONTROL=y
+ CONFIG_OF_SPL_REMOVE_PROPS="pinctrl-0 pinctrl-names clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
+-CONFIG_ENV_IS_IN_MMC=y
++CONFIG_ENV_IS_IN_SPI_FLASH=y
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_SPL_DM_SEQ_ALIAS=y
+ CONFIG_ROCKCHIP_GPIO=y
+ CONFIG_SYS_I2C_ROCKCHIP=y
+ CONFIG_MISC=y
+@@ -35,6 +39,10 @@ CONFIG_MMC_DW=y
+ CONFIG_MMC_DW_ROCKCHIP=y
+ CONFIG_MMC_SDHCI=y
+ CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_SF_DEFAULT_BUS=1
++CONFIG_SPI_FLASH_GIGADEVICE=y
++CONFIG_SPI_FLASH_WINBOND=y
++CONFIG_SPI_FLASH_XTX=y
+ CONFIG_DM_ETH=y
+ CONFIG_ETH_DESIGNWARE=y
+ CONFIG_GMAC_ROCKCHIP=y
+@@ -50,6 +58,7 @@ CONFIG_RAM_RK3399_LPDDR4=y
+ CONFIG_DM_RESET=y
+ CONFIG_BAUDRATE=1500000
+ CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_ROCKCHIP_SPI=y
+ CONFIG_SYSRESET=y
+ CONFIG_USB=y
+ CONFIG_USB_XHCI_HCD=y
+diff --git a/configs/rock-pi-4c-rk3399_defconfig b/configs/rock-pi-4c-rk3399_defconfig
+index 9c2c9e2a78..73f0a2b75e 100644
+--- a/configs/rock-pi-4c-rk3399_defconfig
++++ b/configs/rock-pi-4c-rk3399_defconfig
+@@ -7,6 +7,8 @@ CONFIG_ROCKCHIP_RK3399=y
+ CONFIG_TARGET_EVB_RK3399=y
+ CONFIG_DEBUG_UART_BASE=0xFF1A0000
+ CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_SPL_SPI_FLASH_SUPPORT=y
++CONFIG_SPL_SPI_SUPPORT=y
+ CONFIG_DEFAULT_DEVICE_TREE="rk3399-rock-pi-4c"
+ CONFIG_DEBUG_UART=y
+ # CONFIG_ANDROID_BOOT_IMAGE is not set
+@@ -16,6 +18,7 @@ CONFIG_MISC_INIT_R=y
+ # CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
+ CONFIG_SPL_STACK_R=y
+ CONFIG_SPL_STACK_R_MALLOC_SIMPLE_LEN=0x10000
++CONFIG_SPL_SPI_LOAD=y
+ CONFIG_TPL=y
+ CONFIG_CMD_BOOTZ=y
+ CONFIG_CMD_GPT=y
+@@ -26,8 +29,9 @@ CONFIG_CMD_USB=y
+ CONFIG_CMD_TIME=y
+ CONFIG_SPL_OF_CONTROL=y
+ CONFIG_OF_SPL_REMOVE_PROPS="pinctrl-0 pinctrl-names clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
+-CONFIG_ENV_IS_IN_MMC=y
++CONFIG_ENV_IS_IN_SPI_FLASH=y
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_SPL_DM_SEQ_ALIAS=y
+ CONFIG_ROCKCHIP_GPIO=y
+ CONFIG_SYS_I2C_ROCKCHIP=y
+ CONFIG_MISC=y
+@@ -35,6 +39,10 @@ CONFIG_MMC_DW=y
+ CONFIG_MMC_DW_ROCKCHIP=y
+ CONFIG_MMC_SDHCI=y
+ CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_SF_DEFAULT_BUS=1
++CONFIG_SPI_FLASH_GIGADEVICE=y
++CONFIG_SPI_FLASH_WINBOND=y
++CONFIG_SPI_FLASH_XTX=y
+ CONFIG_DM_ETH=y
+ CONFIG_ETH_DESIGNWARE=y
+ CONFIG_GMAC_ROCKCHIP=y
+@@ -50,6 +58,7 @@ CONFIG_RAM_RK3399_LPDDR4=y
+ CONFIG_DM_RESET=y
+ CONFIG_BAUDRATE=1500000
+ CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_ROCKCHIP_SPI=y
+ CONFIG_SYSRESET=y
+ CONFIG_USB=y
+ CONFIG_USB_XHCI_HCD=y

--- a/boards/radxa/default.nix
+++ b/boards/radxa/default.nix
@@ -1,0 +1,16 @@
+{ rockchipRK399 }:
+
+{
+  radxa-RockPi4C = rockchipRK399 {
+    boardIdentifier = "radxa-rockPi4C";
+    defconfig = "rock-pi-4c-rk3399_defconfig";
+    SPISize = 4 * 1024 * 1024; # 4 MiB
+    patches = [
+      # Based on https://github.com/armbian/build/blob/master/patch/u-boot/u-boot-rockchip64/board-rock-pi-4-enable-spi-flash.patch
+      ./0001-rockpi4-rk3399-add-spi-support.patch
+      # From https://github.com/armbian/build/blob/master/patch/u-boot/u-boot-rockchip64/general-add-xtx-spi-nor-chips.patch
+      ./general-add-xtx-spi-nor-chips.patch
+    ];
+    withSPI = true;
+  };
+}

--- a/boards/radxa/general-add-xtx-spi-nor-chips.patch
+++ b/boards/radxa/general-add-xtx-spi-nor-chips.patch
@@ -1,0 +1,33 @@
+diff --git a/drivers/mtd/spi/Kconfig b/drivers/mtd/spi/Kconfig
+index 018e8c59..8b0033b8 100644
+--- a/drivers/mtd/spi/Kconfig
++++ b/drivers/mtd/spi/Kconfig
+@@ -152,6 +152,12 @@ config SPI_FLASH_XMC
+ 	  Add support for various XMC (Wuhan Xinxin Semiconductor
+ 	  Manufacturing Corp.) SPI flash chips (XM25xxx)
+ 
++config SPI_FLASH_XTX
++	bool "XTX SPI flash support"
++	help
++	  Add support for various XTX (Shenzhen Xin Tian Xia Tech)
++	  SPI flash chips (XM25xxx)
++
+ endif
+ 
+ config SPI_FLASH_USE_4K_SECTORS
+diff --git a/drivers/mtd/spi/spi-nor-ids.c b/drivers/mtd/spi/spi-nor-ids.c
+index 114ebacd..3526a20b 100644
+--- a/drivers/mtd/spi/spi-nor-ids.c
++++ b/drivers/mtd/spi/spi-nor-ids.c
+@@ -319,6 +319,11 @@ const struct flash_info spi_nor_ids[] = {
+ 	/* XMC (Wuhan Xinxin Semiconductor Manufacturing Corp.) */
+ 	{ INFO("XM25QH64A", 0x207017, 0, 64 * 1024, 128, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ INFO("XM25QH128A", 0x207018, 0, 64 * 1024, 256, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++#endif
++#ifdef CONFIG_SPI_FLASH_XTX
++	/* XTX (Shenzhen Xin Tian Xia Tech) */
++	{ INFO("XT25F32B", 0x0b4016, 0, 64 * 1024, 64, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++	{ INFO("XT25F128B", 0x0b4018, 0, 64 * 1024, 256, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ #endif
+ 	{ },
+ };


### PR DESCRIPTION
This PR adds support for the [Radxa RockPi 4C](https://wiki.radxa.com/Rockpi4/hardware). 
Due to the close relation to the other models, they are probably also easy to add.

Tested:

 - Booting from NVMe (Crucial P2 CT250P2SSD8)
 - Boot Menu (over `screen`)

Untested:

 - ~~Graphical output (Board has microHDMI and mDP, no output on mDP)~~ Output is on microHDMI

For flashing, I followed [the official instructions for flashing over USB in maskmode](https://wiki.radxa.com/Rockpi4/dev/spi-install).