### PR TITLE
Add pine h64 board

### DIFF
--- a/boards/pine64-pineH64A/0001-sunxi-dts-add-device-tree-for-pine-H64-model-B.patch
+++ b/boards/pine64-pineH64A/0001-sunxi-dts-add-device-tree-for-pine-H64-model-B.patch
@@ -1,0 +1,90 @@
+From 40b6a302e4e1613476e6a92620d7ceefb239831f Mon Sep 17 00:00:00 2001
+From: Daniel Wagenknecht <dwagenk@mailbox.org>
+Date: Sun, 12 Dec 2021 01:15:54 +0100
+Subject: [PATCH 1/4] sunxi: dts: add device-tree for pine H64 model B
+
+Add the device-tree for pine H64 model B from 5.15 mainline linux.
+
+The differences between the pine H64 boards model A and model B are
+irrelevant inside u-boot, but the device-tree name is relevant as
+default for selecting the correct device-tree when booting linux.
+
+Signed-off-by: Daniel Wagenknecht <dwagenk@mailbox.org>
+---
+ arch/arm/dts/Makefile                       |  1 +
+ arch/arm/dts/sun50i-h6-pine-h64-model-b.dts | 51 +++++++++++++++++++++
+ 2 files changed, 52 insertions(+)
+ create mode 100644 arch/arm/dts/sun50i-h6-pine-h64-model-b.dts
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index fc16a57e60..de2e4ca66b 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -642,6 +642,7 @@ dtb-$(CONFIG_MACH_SUN50I_H6) += \
+ 	sun50i-h6-orangepi-lite2.dtb \
+ 	sun50i-h6-orangepi-one-plus.dtb \
+ 	sun50i-h6-pine-h64.dtb \
++	sun50i-h6-pine-h64-model-b.dtb \
+ 	sun50i-h6-tanix-tx6.dtb
+ dtb-$(CONFIG_MACH_SUN50I_H616) += \
+ 	sun50i-h616-orangepi-zero2.dtb
+diff --git a/arch/arm/dts/sun50i-h6-pine-h64-model-b.dts b/arch/arm/dts/sun50i-h6-pine-h64-model-b.dts
+new file mode 100644
+index 0000000000..686f58e770
+--- /dev/null
++++ b/arch/arm/dts/sun50i-h6-pine-h64-model-b.dts
+@@ -0,0 +1,51 @@
++// SPDX-License-Identifier: (GPL-2.0+ or MIT)
++/*
++ * Copyright (C) 2019 Corentin LABBE <clabbe@baylibre.com>
++ */
++
++#include "sun50i-h6-pine-h64.dts"
++
++/ {
++	model = "Pine H64 model B";
++	compatible = "pine64,pine-h64-model-b", "allwinner,sun50i-h6";
++
++	/delete-node/ reg_gmac_3v3;
++
++	wifi_pwrseq: wifi_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&r_pio 1 3 GPIO_ACTIVE_LOW>; /* PM3 */
++		post-power-on-delay-ms = <200>;
++	};
++};
++
++&hdmi_connector {
++	/delete-property/ ddc-en-gpios;
++};
++
++&emac {
++	phy-supply = <&reg_aldo2>;
++};
++
++&mmc1 {
++	vmmc-supply = <&reg_cldo3>;
++	vqmmc-supply = <&reg_aldo1>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++};
++
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
++	uart-has-rtscts;
++	status = "okay";
++
++	bluetooth {
++		compatible = "realtek,rtl8723bs-bt";
++		device-wake-gpios = <&r_pio 1 2 GPIO_ACTIVE_HIGH>; /* PM2 */
++		host-wake-gpios = <&r_pio 1 1 GPIO_ACTIVE_HIGH>; /* PM1 */
++		enable-gpios = <&r_pio 1 4 GPIO_ACTIVE_HIGH>; /* PM4 */
++		max-speed = <1500000>;
++	};
++};
+-- 
+2.33.1
+

--- a/boards/pine64-pineH64A/0002-sunxi-configs-add-defconfig-for-pine-H64-model-B.patch
+++ b/boards/pine64-pineH64A/0002-sunxi-configs-add-defconfig-for-pine-H64-model-B.patch
@@ -1,0 +1,48 @@
+From df5c906043659276240e62ce003217ecea545bdb Mon Sep 17 00:00:00 2001
+From: Daniel Wagenknecht <dwagenk@mailbox.org>
+Date: Wed, 8 Dec 2021 23:05:42 +0100
+Subject: [PATCH 2/4] sunxi: configs: add defconfig for pine H64 model B
+
+It almost identical to the defconfig for pine H64 model A with only
+the CONFIG_DEFUALT_DEVICE_TREE adapted.
+
+The differences between the boards model A and model B are irrelevant
+inside u-boot, but the device-tree name is relevant as default for
+selecting the correct device-tree when booting linux.
+
+Signed-off-by: Daniel Wagenknecht <dwagenk@mailbox.org>
+---
+ configs/pine_h64-model-b_defconfig | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+ create mode 100644 configs/pine_h64-model-b_defconfig
+
+diff --git a/configs/pine_h64-model-b_defconfig b/configs/pine_h64-model-b_defconfig
+new file mode 100644
+index 0000000000..4645ceaa54
+--- /dev/null
++++ b/configs/pine_h64-model-b_defconfig
+@@ -0,0 +1,21 @@
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_DEFAULT_DEVICE_TREE="sun50i-h6-pine-h64-model-b"
++CONFIG_SPL=y
++CONFIG_MACH_SUN50I_H6=y
++CONFIG_SUNXI_DRAM_H6_LPDDR3=y
++CONFIG_MACPWR="PC16"
++CONFIG_MMC0_CD_PIN="PF6"
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
++CONFIG_USB3_VBUS_PIN="PL5"
++CONFIG_SPL_SPI_SUNXI=y
++# CONFIG_PSCI_RESET is not set
++# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_SUN8I_EMAC=y
++CONFIG_PHY_SUN50I_USB3=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_DWC3=y
++# CONFIG_USB_DWC3_GADGET is not set
+-- 
+2.33.1
+

--- a/boards/pine64-pineH64A/0003-sunxi-SPI-fix-pinmuxing-for-Allwinner-H6-SoCs.patch
+++ b/boards/pine64-pineH64A/0003-sunxi-SPI-fix-pinmuxing-for-Allwinner-H6-SoCs.patch
@@ -1,0 +1,37 @@
+From 433e02fc464327463f585263c657d27b2ac3228b Mon Sep 17 00:00:00 2001
+From: Daniel Wagenknecht <dwagenk@mailbox.org>
+Date: Sat, 11 Dec 2021 01:46:56 +0100
+Subject: [PATCH 3/4] sunxi: SPI: fix pinmuxing for Allwinner H6 SoCs
+
+The driver for SPI0 on Allwinner H6 SoCs did not use the correct define
+SUN50I_GPC_SPI0 for the pin function, but one for a different Allwinner
+SoC series.
+
+Fix the conditionals to use the correct define for H6 SoCs. This matches
+the conditional logic in the SPL spi driver.
+
+Tested by probing the spi-flash on a pine64_h64-model-b board with
+adapted device-tree (disable mmc2, enable spi0).
+
+Signed-off-by: Daniel Wagenknecht <dwagenk@mailbox.org>
+---
+ drivers/spi/spi-sunxi.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/spi/spi-sunxi.c b/drivers/spi/spi-sunxi.c
+index 4ca5d3a93a..9e11f0dc1b 100644
+--- a/drivers/spi/spi-sunxi.c
++++ b/drivers/spi/spi-sunxi.c
+@@ -249,7 +249,8 @@ static int sun4i_spi_parse_pins(struct udevice *dev)
+ 			if (pin < 0)
+ 				break;
+ 
+-			if (IS_ENABLED(CONFIG_MACH_SUN50I))
++			if (IS_ENABLED(CONFIG_MACH_SUN50I) ||
++			    IS_ENABLED(CONFIG_MACH_SUN50I_H6))
+ 				sunxi_gpio_set_cfgpin(pin, SUN50I_GPC_SPI0);
+ 			else
+ 				sunxi_gpio_set_cfgpin(pin, SUNXI_GPC_SPI0);
+-- 
+2.33.1
+

--- a/boards/pine64-pineH64A/0004-pine-H64-A-enable-SPI-disable-eMMC.patch
+++ b/boards/pine64-pineH64A/0004-pine-H64-A-enable-SPI-disable-eMMC.patch
@@ -1,0 +1,54 @@
+From 259ca24e9cc9a8502a9390292b84be6229a26490 Mon Sep 17 00:00:00 2001
+From: Daniel Wagenknecht <dwagenk@mailbox.org>
+Date: Sun, 12 Dec 2021 01:36:34 +0100
+Subject: [PATCH] pine H64 A: enable SPI, disable eMMC
+
+---
+ arch/arm/dts/sun50i-h6-pine-h64.dts | 6 ++----
+ configs/pine_h64_defconfig          | 5 +++++
+ 2 files changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm/dts/sun50i-h6-pine-h64.dts b/arch/arm/dts/sun50i-h6-pine-h64.dts
+index b868ad17af..6ea2a8b291 100644
+--- a/arch/arm/dts/sun50i-h6-pine-h64.dts
++++ b/arch/arm/dts/sun50i-h6-pine-h64.dts
+@@ -144,7 +144,7 @@
+ 	cap-mmc-hw-reset;
+ 	mmc-hs200-1_8v;
+ 	bus-width = <8>;
+-	status = "okay";
++	status = "disabled";
+ };
+ 
+ &ohci0 {
+@@ -301,13 +301,11 @@
+ /*
+  * The CS pin is shared with the MMC2 CMD pin, so we cannot have the SPI
+  * flash and eMMC at the same time, as one of them would fail probing.
+- * Disable SPI0 in here, to prefer the more useful eMMC. U-Boot can
+- * fix this up in no eMMC is connected.
+  */
+ &spi0 {
+ 	pinctrl-0 = <&spi0_pins>, <&spi0_cs_pin>;
+ 	pinctrl-names = "default";
+-	status = "disabled";
++	status = "okay";
+ 
+ 	flash@0 {
+ 		compatible = "winbond,w25q128", "jedec,spi-nor";
+diff --git a/configs/pine_h64_defconfig b/configs/pine_h64_defconfig
+index 1928509dd7..4a16c77e17 100644
+--- a/configs/pine_h64_defconfig
++++ b/configs/pine_h64_defconfig
+@@ -19,3 +19,8 @@ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_OHCI_HCD=y
+ CONFIG_USB_DWC3=y
+ # CONFIG_USB_DWC3_GADGET is not set
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_DM_SPI_FLASH=y
++CONFIG_SPI_SUNXI=y
++CONFIG_SPI_FLASH_WINBOND=y
+-- 
+2.33.1
+

--- a/boards/pine64-pineH64A/0005-pine-H64-B-enable-SPI-disable-eMMC.patch
+++ b/boards/pine64-pineH64A/0005-pine-H64-B-enable-SPI-disable-eMMC.patch
@@ -1,0 +1,25 @@
+From 259ca24e9cc9a8502a9390292b84be6229a26490 Mon Sep 17 00:00:00 2001
+From: Daniel Wagenknecht <dwagenk@mailbox.org>
+Date: Sun, 12 Dec 2021 01:36:34 +0100
+Subject: [PATCH] pine H64 B: enable SPI, disable eMMC
+
+---
+ configs/pine_h64-model-b_defconfig  | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/configs/pine_h64-model-b_defconfig b/configs/pine_h64-model-b_defconfig
+index 4645ceaa54..8130d027d0 100644
+--- a/configs/pine_h64-model-b_defconfig
++++ b/configs/pine_h64-model-b_defconfig
+@@ -19,3 +19,8 @@ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_OHCI_HCD=y
+ CONFIG_USB_DWC3=y
+ # CONFIG_USB_DWC3_GADGET is not set
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_DM_SPI_FLASH=y
++CONFIG_SPI_SUNXI=y
++CONFIG_SPI_FLASH_WINBOND=y
+-- 
+2.33.1
+

--- a/boards/pine64-pineH64A/default.nix
+++ b/boards/pine64-pineH64A/default.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ...}:
+
+{
+  device = {
+    manufacturer = "PINE64";
+    name = lib.mkDefault "H64A";
+    identifier = lib.mkDefault "pine64-pineH64A";
+    productPageURL = "https://www.pine64.org/pine-h64/";
+  };
+
+  hardware = {
+    soc = "allwinner-h6";
+    withDisplay = false;
+    SPISize = 16 * 1024 * 1024; # 16 MiB
+  };
+
+  Tow-Boot = {
+    defconfig = lib.mkDefault "pine_h64_defconfig";
+    patches = [
+      ./0001-sunxi-dts-add-device-tree-for-pine-H64-model-B.patch
+      ./0002-sunxi-configs-add-defconfig-for-pine-H64-model-B.patch
+      ./0003-sunxi-SPI-fix-pinmuxing-for-Allwinner-H6-SoCs.patch
+      ./0004-pine-H64-A-enable-SPI-disable-eMMC.patch
+      ./0005-pine-H64-B-enable-SPI-disable-eMMC.patch
+    ];
+    config = [
+      (helpers: with helpers; {
+        CMD_POWEROFF = no;
+      })
+    ];
+  };
+}

--- a/boards/pine64-pineH64B/default.nix
+++ b/boards/pine64-pineH64B/default.nix
@@ -1,0 +1,21 @@
+{ config, lib, pkgs, ...}:
+
+{
+  imports = [
+    ../pine64-pineH64A
+  ];
+
+  device = {
+    name = "H64B";
+    identifier = "pine64-pineH64B";
+    productPageURL = "https://www.pine64.org/pine-h64-ver-b/";
+  };
+
+  hardware = {
+    allwinner.crust.defconfig = "pine_h64_defconfig";
+  };
+
+  Tow-Boot = {
+    defconfig = "pine_h64-model-b_defconfig";
+  };
+}

--- a/modules/hardware/allwinner/default.nix
+++ b/modules/hardware/allwinner/default.nix
@@ -13,6 +13,7 @@ let
     "allwinner-a64"
     "allwinner-h3"
     "allwinner-h5"
+    "allwinner-h6"
   ];
   anyAllwinner = lib.any (soc: config.hardware.socs.${soc}.enable) allwinnerSOCs;
   anyAllwinner64 = anyAllwinner && config.system.system == "aarch64-linux";
@@ -37,6 +38,12 @@ in
         type = types.bool;
         default = false;
         description = "Enable when SoC is Allwinner H5";
+        internal = true;
+      };
+      allwinner-h6.enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable when SoC is Allwinner H6";
         internal = true;
       };
     };
@@ -104,6 +111,12 @@ in
     })
     (mkIf cfg.allwinner-h5.enable {
       system.system = "aarch64-linux";
+    })
+    (mkIf cfg.allwinner-h6.enable {
+      system.system = "aarch64-linux";
+      Tow-Boot.builder.additionalArguments = {
+        BL31 = lib.mkForce "${pkgs.Tow-Boot.armTrustedFirmwareAllwinnerH6}/bl31.bin";
+      };
     })
 
     # Documentation fragments

--- a/modules/hardware/default.nix
+++ b/modules/hardware/default.nix
@@ -59,6 +59,13 @@ in
           internal = true;
         };
       };
+      withDisplay = mkOption{
+        type = types.bool;
+        default = true;
+        description = ''
+          When true, the build is made assuming the display drivers are available and work.
+        '';
+      };
     };
   };
   config = mkMerge [

--- a/modules/tow-boot/options.nix
+++ b/modules/tow-boot/options.nix
@@ -78,7 +78,7 @@ in
 
       withLogo = mkOption {
         type = types.bool;
-        default = true;
+        default = config.hardware.withDisplay;
         description = ''
           Build with support for the logo.
 

--- a/support/overlay/arm-trusted-firmware/default.nix
+++ b/support/overlay/arm-trusted-firmware/default.nix
@@ -89,6 +89,12 @@ in {
     filesToInstall = ["build/${platform}/release/bl31.bin"];
   };
 
+  armTrustedFirmwareAllwinnerH6 = buildArmTrustedFirmware rec {
+    platform = "sun50i_h6";
+    extraMeta.platforms = [ "aarch64-linux" ];
+    filesToInstall = [ "build/${platform}/release/bl31.bin" ];
+  };
+
   armTrustedFirmwareQemu = buildArmTrustedFirmware rec {
     platform = "qemu";
     extraMeta.platforms = ["aarch64-linux"];

--- a/support/overlay/overlay.nix
+++ b/support/overlay/overlay.nix
@@ -54,6 +54,7 @@ in
 
     inherit (callPackage ./arm-trusted-firmware { })
       armTrustedFirmwareAllwinner
+      armTrustedFirmwareAllwinnerH6
       armTrustedFirmwareRK3399
       armTrustedFirmwareS905
     ;


### PR DESCRIPTION
This adds support for the pine H64 board, both the A and the B variant (which are almost identical). An adapted builder for the Arm-Trusted-Firmware for the Allwinner H6 SOC was also necessary.

https://wiki.pine64.org/index.php/PINE_H64

I tested the `shared.disk-image.img`  with the B variant of the board.

--- List updated ---
- [x] Tow-Boot is starting and I get the boot selection menu via serial connection when pressing CTRL-C or ESC.
- [x] Switching out the SD Card and selecting "Boot from SD" works
- [x] USB: lower of the two USB2 port works
- [ ] USB: The upper USB2 port one and the USB3 Port do not work (even after update to v2021.10)
- [ ] HDMI: not working (apparently no support in u-boot, see `arch/arm/mach-sunxi/Kconfig` dependecy chain `VIDEO_HDMI->VIDEO_SUNXI->!SUN50I_GEN_H6`)
- [x] netbooting (DHCP or PXE): at least the IP gets assigned, did *not* set up a TFTP server for testing
- [ ] eMMC: I do not have an eMMC module and thus didn't test booting form it
- [x] SPI flash: works, though BOOTROM attempts to boot from SD and eMMC first