### PR TITLE
 arm-trusted-firmware: 2.5 -> 2.6

### DIFF
--- a/boards/pine64/pinebook-pro.nix
+++ b/boards/pine64/pinebook-pro.nix
@@ -1,15 +1,5 @@
-{ rockchipRK399, fetchpatch, armTrustedFirmwareRK3399 }:
+{ rockchipRK399, fetchpatch }:
 
-let
-  TF-A = armTrustedFirmwareRK3399.overrideAttrs({ patches ? [ ], ...}: {
-    patches = [
-      (fetchpatch {
-        url = "https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git/patch/?id=1738a04b588200d3e737382da07e4f967305b4f2";
-        sha256 = "09rmwa9568wac9y8xf0jvnmhdga7j2hp02gk4451w0v2is3sfchg";
-      })
-    ] ++ patches;
-  });
-in
 rockchipRK399 {
   boardIdentifier = "pine64-pinebookPro";
   defconfig = "pinebook-pro-rk3399_defconfig";
@@ -32,5 +22,4 @@ rockchipRK399 {
       sha256 = "0aiw9zk8w4msd3v8nndhkspjify0yq6a5f0zdy6mhzs0ilq896c3";
     })
   ];
-  BL31 = "${TF-A}/bl31.elf";
 }

--- a/support/builders/tow-boot/default.nix
+++ b/support/builders/tow-boot/default.nix
@@ -12,19 +12,12 @@
 { stdenv
 , lib
 , fetchurl
-, fetchpatch
-, fetchFromGitHub
 , bc
 , bison
 , dtc
 , flex
 , openssl
 , swig
-, meson-tools
-, armTrustedFirmwareAllwinner
-, armTrustedFirmwareRK3328
-, armTrustedFirmwareRK3399
-, armTrustedFirmwareS905
 , buildPackages
 , runCommandNoCC
 }:

--- a/support/overlay/arm-trusted-firmware/default.nix
+++ b/support/overlay/arm-trusted-firmware/default.nix
@@ -15,7 +15,7 @@ let
             , platform ? null
             , extraMakeFlags ? []
             , extraMeta ? {}
-            , version ? "2.5"
+            , version ? "2.6"
             , ... } @ args:
            stdenv.mkDerivation ({
 
@@ -26,7 +26,7 @@ let
       owner = "ARM-software";
       repo = "arm-trusted-firmware";
       rev = "v${version}";
-      sha256 = "0w3blkqgmyb5bahlp04hmh8abrflbzy0qg83kmj1x9nv4mw66f3b";
+      sha256 = "sha256-qT9DdTvMcUrvRzgmVf2qmKB+Rb1WOB4p1rM+fsewGcg=";
     };
 
     depsBuildBuild = [ buildPackages.stdenv.cc ];


### PR DESCRIPTION
Tested on:

 - RK3399 (Pinebook Pro)
 - A64 (Pinebook (A64))

I verified the Pinebook Pro *deep* sleep worked.