### PR TITLE
support/docker: Add build shim

### DIFF
--- a/doc/development-guide.md
+++ b/doc/development-guide.md
@@ -15,20 +15,42 @@ The author uses NixOS, but NixOS is not a requirement.
 Only *Nix* the package manager is required to build this project. It can be
 installed on any Linux distribution.
 
+It is preferred to install from the official Nix installer. Using the
+distribution-packaged Nix may not work.
+
 #### I don't want to or can't install `Nix` on my system
 
 Sorry.
 
-Though you can use a Docker container image **TODO** that is pre-configured to
-work well with this project.
+Though you can use a build shim that uses a Docker container.
 
 Using Nix through Docker is not ideal, but should work when working under
 specific conditions.
 
-While Nix works on macOS, this project require a Linux builder to work. Using
-the Docker builder is an alternative to setting up a Linux virtual machine.
-After all, Docker on macOS is a specialized Linux virtual machine. **TO BE TESTED**
+When using the build shim, replace `nix-build` invocations with the path to 
+the shim (e.g.`./support/docker/build.sh`). Note that this only works if the
+command does not reference a nix file directly.
 
+#### I'm not on a Linux system
+
+While Nix works on macOS, this project require a Linux builder to work.
+Using the Docker build shim may work, testing is needed, contributions welcome.
+
+
+I just want to build
+--------------------
+
+You still should read a bit more past this section, but if you absolutely only
+want to build, here's how you can build the `uBoot-sandbox` board.
+
+```
+ $ nix-build -A uBoot-sandbox
+```
+
+After the build is finished successfully, a `result` symlink will refer to the
+build output. The build output by default is the content of the archive.
+
+* * *
 
 A primer on Nix
 ---------------

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -80,3 +80,10 @@ but the size has been chosen to allow further expansion if needed.
 Using the *shared storage* strategy, you can simulate *dedicated storage* by
 **not** installing and using the storage media the platform firmware lives
 on.
+
+
+Building Tow-Boot
+-----------------
+
+This is not a *getting started* topic exactly. This is covered in the
+*[Development Guide](development-guide.md)* section.

--- a/support/docker/build.sh
+++ b/support/docker/build.sh
@@ -55,10 +55,12 @@ if [ -e /Tow-Boot ]; then
 	nix-build --cores 0 "$@"
 	)
 
+	stderr.printf "(Unwrapping store paths...)\n"
+
 	# Unwrap the `result` symlink
 	out=$(readlink -f result)
 	rm result
-	cp -r "$out" result
+	cp -vr "$out" result >&2
 	chown -R "$REAL_UID:$REAL_GID" result
 else
 	if [[ "$relative_dir" =~ ^/ ]]; then

--- a/support/docker/build.sh
+++ b/support/docker/build.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+#
+# This script is ran from outside the docker environment, to run itself into
+# the docker environment.
+#
+# It will automatically handle calling `nix-build` correctly, and unwrapping
+# the `result` symlink into a real directory.
+#
+# A `Tow-Boot--nix-store` volume will be automatically created. It will hold
+# the `/nix/store` as a local binary cache. Otherwise the toolchain must be
+# downloaded again every invocation.
+#
+# This is not a one-to-one replacement for Nix, but should be sufficient for
+# basic building locally without installing Nix globally, if Docker is deemed
+# more appropriate.
+#
+
+set -e
+set -u
+set -o pipefail
+PS4=" $ "
+
+_nix_docker() {
+	local STORE_VOLUME
+	STORE_VOLUME="$(docker volume create "Tow-Boot--nix-store")"
+
+	docker run \
+		--volume "$STORE_VOLUME:/nix" \
+		--volume "$(cd "$(dirname "$0")/../.."; pwd):/Tow-Boot" \
+		-it nixos/nix \
+		"$@"
+}
+
+if [ -e /Tow-Boot ]; then
+	REAL_UID="$1"; shift
+	REAL_GID="$1"; shift
+
+	cd /Tow-Boot
+
+	# Cleanup a leftover result (unclean and rude)
+	if [ -e result ]; then
+		rm -rf result
+	fi
+
+	# Call `nix-build`, showing the user the actual invocation.
+	(set -x
+	nix-build --cores 0 "$@"
+	)
+
+	# Unwrap the `result` symlink
+	out=$(readlink -f result)
+	rm result
+	cp -r "$out" result
+	chown -R "$REAL_UID:$REAL_GID" result
+else
+	# Outside the docker environment, we're calling this script in the container.
+	_nix_docker /Tow-Boot/support/docker/build.sh \
+		"$(id -u)" "$(id -g)" \
+		"$@"
+fi


### PR DESCRIPTION
This adds a shim allowing end-users to invoke a containerized Nix
instance, in a manner compatible to using `nix-build`.

```
 $ support/docker/build.sh -A pine64-pineA64LTS
```

This is equivalent to

```
 $ nix-build -A pine64-pineA64LTS
```

The semantics vary a little. *Only* the `result` symlink is resolved and
replaced with the store path contents. This means that using
`--out-link` is not supported at this time, and multiple build outputs
won't work as expected.

This should be sufficient though.

* * *

This is desirable as an *alternative known good way* to invoke the Nix build on non-NixOS. Installing Nix globally using the upstream installer should work just as well. Using the distro-provided packages is hit-and-miss, due to unclear reasons, depending on the distro.

*In addition*, it may be useful for macOS or Windows users using *whatever cursed thing docker provides for them*.

* * *

Tested on Ubuntu

![image](https://user-images.githubusercontent.com/132835/151468825-f85c7e53-9f03-4f6f-b25a-6716c80a35d3.png)


Fixes #5