### PR TITLE
Go back to the previous build UX

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,22 +1,51 @@
-#
-# *This is not an external interface*. Do not import this file from your
-# project or configuration, as this may become opinionated in the future.
-#
-{ device ? null, configuration ? { } }@args:
+{ device ? null
+, configuration ? { }
+, silent ? false
+, pkgs ? import ./nixpkgs.nix { }
+}@args:
 
-import ./support/nix/eval-with-configuration.nix (args // {
-  inherit device;
-  verbose = true;
-  configuration = {
-    imports = [
-      configuration
-      (
-        { lib, ... }:
-        {
-          # Special configs for imperative use only here
-          system.automaticCross = true;
-        }
-      )
-    ];
-  };
-})
+let
+  all-devices =
+    builtins.filter
+    (d: builtins.pathExists (./. + "/boards/${d}/default.nix"))
+    (builtins.attrNames (builtins.readDir ./boards))
+  ;
+
+  evalFor = device:
+    import ./support/nix/eval-with-configuration.nix (args // {
+      inherit device;
+      inherit pkgs;
+      verbose = true;
+      configuration = {
+        imports = [
+          configuration
+          (
+            { lib, ... }:
+            {
+              # Special configs for imperative use only here
+              system.automaticCross = true;
+            }
+          )
+        ];
+      };
+    })
+  ;
+
+  outputs = builtins.listToAttrs (builtins.map (device: { name = device; value = evalFor device; }) all-devices);
+  outputsCount = builtins.length (builtins.attrNames outputs);
+
+  pkgs = import ./nixpkgs.nix {};
+in
+
+outputs // {
+  ___aaallIsBeingBuilt = if silent then null else (
+  builtins.trace (pkgs.lib.removePrefix "trace: " ''
+    trace: +--------------------------------------------------+
+    trace: | Notice: ${pkgs.lib.strings.fixedWidthString 3 " " (toString outputsCount)} outputs will be built.               |
+    trace: |                                                  |
+    trace: | You may prefer to build a specific output using: |
+    trace: |                                                  |
+    trace: |   $ nix-build -A vendor-board                    |
+    trace: +--------------------------------------------------+
+ '') null);
+}

--- a/support/nix/eval-with-configuration.nix
+++ b/support/nix/eval-with-configuration.nix
@@ -59,22 +59,8 @@ let
 in
 (
   # Break gracefully if `device` is not set.
-  # TODO: better document how to provide a device
   if device == null then throw ''
     Please provide a device to build for.
-    =====================================
-
-    Add either of the following parameters:
-
-      --argstr device vendorName-deviceName
-
-    or
-
-      --arg device ./boards/vendorName-deviceName
-
-    The former is equivalent to the latter.
-    The format with a path allows using a device declared out of tree.
-
   '' else
 
   # Maybe print a banner for the device eval.
@@ -91,7 +77,7 @@ in
 # Hijack the `default` output, and shove useful eval attributes in passthru.
 # This makes the default build produce a useful result, and allows usage such as:
 #
-#    $ nix-build --argstr device ... -A build.archive
+#    $ nix-build -A vendorName-deviceName.build.archive
 #
 eval.config.build.default.overrideAttrs({ passthru ? {}, ... }: {
   passthru = passthru // {


### PR DESCRIPTION
I agree that `--argstr device ...` is inconvenient. Let's roll back the same UX as was used previously, but this time using the new eval.

cc @colemickens 