### PR TITLE
patches: Revert RK3399 boot order re-ordering from upstream

### DIFF
--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -39,6 +39,7 @@ in
 
             # Intrusive opinionated patches
             (base + "/0001-Tow-Boot-sunxi-ignore-mmc_auto-force-SD-then-eMMC.patch")
+            (base + "/0001-Revert-rockchip-Fix-MMC-boot-order.patch")
           ];
         };
       in

--- a/support/u-boot/2021.10/patches/0001-Revert-rockchip-Fix-MMC-boot-order.patch
+++ b/support/u-boot/2021.10/patches/0001-Revert-rockchip-Fix-MMC-boot-order.patch
@@ -1,0 +1,35 @@
+From ba65875dc7311d251f2e4c12179c9a589e997477 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Sun, 6 Feb 2022 20:16:55 -0500
+Subject: [PATCH] Revert "rockchip: Fix MMC boot order"
+
+This reverts commit b212ad24a604b00b240add35516b7381965deb31.
+
+This "fix" goes against the preferred boot order for Tow-Boot, which
+prefers internal storage first.
+---
+ include/configs/rockchip-common.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/include/configs/rockchip-common.h b/include/configs/rockchip-common.h
+index ba7061a287c..0b9e24d1db4 100644
+--- a/include/configs/rockchip-common.h
++++ b/include/configs/rockchip-common.h
+@@ -14,11 +14,11 @@
+ 
+ #ifndef CONFIG_SPL_BUILD
+ 
+-/* First try to boot from SD (index 1), then eMMC (index 0) */
++/* First try to boot from SD (index 0), then eMMC (index 1) */
+ #if CONFIG_IS_ENABLED(CMD_MMC)
+ 	#define BOOT_TARGET_MMC(func) \
+-		func(MMC, mmc, 1) \
+-		func(MMC, mmc, 0)
++		func(MMC, mmc, 0) \
++		func(MMC, mmc, 1)
+ #else
+ 	#define BOOT_TARGET_MMC(func)
+ #endif
+-- 
+2.34.0
+


### PR DESCRIPTION
Fixes #86.