### PR TITLE
doc: Use *platform firmware*

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -24,8 +24,8 @@ First, the "any `AArch64` devices" has to assume that the operating system can
 run on those devices. For this question, we assume the operating system does.
 
 It all depends on whether the systems require dedicated or shared storage for
-the firmware. If the system requires shared storage, and can only boot the
-initial firmware from the SD card, the SD card must contain its firmware. This
+the firmware. If the system requires shared storage, and can only start the
+platform firmware from the SD card, the SD card must contain its firmware. This
 will probably not work well for two different enough platforms.
 
 Though, still assuming the operating system can boot on all the devices you

--- a/doc/distributions/fedora.md
+++ b/doc/distributions/fedora.md
@@ -26,7 +26,7 @@ partitions you have created.
 > partition, it may work as well.
 
 When using **dedicated firmware storage**, nothing special has to be done to
-keep the *initial boot firmware* working.
+keep the *platform firmware* working.
 
 
 Bootloader Installation

--- a/doc/distributions/nixos.md
+++ b/doc/distributions/nixos.md
@@ -6,7 +6,7 @@ followed.
 
  - https://nixos.wiki/wiki/NixOS_on_ARM/UEFI
 
-They will refer back to Tow-Boot as a source of *Initial Boot Firmware*.
+They will refer back to Tow-Boot as a source of *Platform Firmware*.
 
 The installation is similar to what it would be with `x86_64`. The main issues
 are noted on the Wiki page.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -2,10 +2,10 @@ Getting Started
 ===============
 
 There are two main general ways to install *Tow-Boot*. Installing to a dedicated
-initial boot firmware storage media, if your board supports it, or installing
+platform firmware storage media, if your board supports it, or installing
 on shared storage.
 
-To know whether your board supports the dedicated storage for the initial boot
+To know whether your board supports the dedicated storage for the platform
 firmware, consult the documentation for your board.
 
 On most boards supporting dedicated storage, it is possible to install using
@@ -27,7 +27,7 @@ possible, but out of scope for this guide.
 Learn about the CPU boot order of your board, and ensure no dedicated or shared
 storage has priority over the one you're going to use. 
 
-> **NOTE**: If another Initial Boot Firmware is present on the dedicated
+> **NOTE**: If another Platform Firmware is present on the dedicated
 > storage for your board, it is possible that it will have priority.
 >
 > You may need to erase it, or do other manipulations on your board to skip it
@@ -61,7 +61,7 @@ already formatted in a controlled manner. The partition table is likely to be
 GPT formatted, but some SoC families force the use of MBR.
 
 The disk will contain a partition, this partition serves to **protect** the
-initial boot firmware. It is important to know that with almost all SoC
+platform firmware. It is important to know that with almost all SoC
 families you **cannot** move the partition. It may be possible to resize it,
 but the size has been chosen to allow further expansion if needed.
 
@@ -78,5 +78,5 @@ but the size has been chosen to allow further expansion if needed.
 > you.
 
 Using the *shared storage* strategy, you can simulate *dedicated storage* by
-**not** installing and using the storage media the initial boot firmware lives
+**not** installing and using the storage media the platform firmware lives
 on.

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -6,10 +6,10 @@ Terminology as used in the project.
 * * *
 
 
-Initial Boot Firmware
----------------------
+Platform Firmware
+-----------------
 
-The *Initial Boot Firmware* is a generic term used to describe the first thing
+The *Platform Firmware* is a generic term used to describe the first thing
 the CPU starts at boot time. On your typical `x86_64` system, it would be what
 was previously called the *BIOS*. Now often diminutively called by the name
 *EFI*. This is what initializes enough of the hardware so that the *operating
@@ -17,7 +17,7 @@ system* can start. Additionally, it often provides facilities for the user to
 do basic configuration, and manage boot options.
 
 In the ARM with SBCs landscape, **U-Boot** is the de facto solution for the
-*Initial Boot Firmware*. Though *U-Boot* is confusingly, but rightly, often
+*Platform Firmware*. Though *U-Boot* is confusingly, but rightly, often
 referred to as a *Boot Loader*. *U-Boot* plays double duties often. It is
 tasked with *initializing the hardware*, and often also used to handle *loading
 and booting* the operating system.
@@ -27,7 +27,7 @@ Boot Loader
 -----------
 
 The *Boot loader* is a program which may or may not be distinct from the
-*Initial Boot Firmware*, which is meant to load a start an *Operating System*.
+*Platform Firmware*, which is meant to load and boot an *Operating System*.
 
 *Boot loaders* are now commonly written following the *UEFI* spec. *GRUB*,
 *rEFInd* and *systemd-boot* are examples of UEFI *boot loaders*.


### PR DESCRIPTION
Fixes #58.

The EBBR spec uses the term *platform firmware* enough to warrant using this instead of trying to coin a confusing new term.