### PR TITLE
tow-boot/builder: Fix Rockchip DTS erroneous 15200 baud rate

### DIFF
--- a/modules/tow-boot/builder.nix
+++ b/modules/tow-boot/builder.nix
@@ -131,7 +131,7 @@ in
             done
             for f in arch/arm/dts/*rk3399*.dts* arch/arm/dts/*rk3328*.dts*; do
               (set -x
-              sed -i"" -e 's/serial2:1500000n8/serial2:15200n8/' "$f"
+              sed -i"" -e 's/serial2:1500000n8/serial2:115200n8/' "$f"
               )
             done
             )


### PR DESCRIPTION
This did not end up causing issues because the other large-scale
replacement was the one that took precedence. This one *may* have caused
issues with `/chosen/stdout` though.

Thank you @Danct12 for noticing.