### PR TITLE
radxa-zero2: Add support for Radxa Zero 2

### DIFF
--- a/boards/radxa-zero2/0001-arch-arm-dts-Sync-amlogic-meson-DT-with-mainline.patch
+++ b/boards/radxa-zero2/0001-arch-arm-dts-Sync-amlogic-meson-DT-with-mainline.patch
@@ -1,0 +1,123 @@
+From a6abcd8a07f8d46d4512eaf8aa05f481cc70c480 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Thu, 10 Feb 2022 20:59:41 -0500
+Subject: [PATCH] arch: arm: dts: Sync amlogic (meson) DT with mainline
+
+---
+ arch/arm/dts/meson-g12-common.dtsi | 31 ++++++++++++++++++++++--------
+ arch/arm/dts/meson-g12b.dtsi       |  4 ++++
+ 2 files changed, 27 insertions(+), 8 deletions(-)
+
+diff --git a/arch/arm/dts/meson-g12-common.dtsi b/arch/arm/dts/meson-g12-common.dtsi
+index 1e83ec5b8c9..00c6f53290d 100644
+--- a/arch/arm/dts/meson-g12-common.dtsi
++++ b/arch/arm/dts/meson-g12-common.dtsi
+@@ -17,6 +17,12 @@
+ 	#address-cells = <2>;
+ 	#size-cells = <2>;
+ 
++	aliases {
++		mmc0 = &sd_emmc_b; /* SD card */
++		mmc1 = &sd_emmc_c; /* eMMC */
++		mmc2 = &sd_emmc_a; /* SDIO */
++	};
++
+ 	chosen {
+ 		#address-cells = <2>;
+ 		#size-cells = <2>;
+@@ -122,9 +128,9 @@
+ 
+ 		pcie: pcie@fc000000 {
+ 			compatible = "amlogic,g12a-pcie", "snps,dw-pcie";
+-			reg = <0x0 0xfc000000 0x0 0x400000
+-			       0x0 0xff648000 0x0 0x2000
+-			       0x0 0xfc400000 0x0 0x200000>;
++			reg = <0x0 0xfc000000 0x0 0x400000>,
++			      <0x0 0xff648000 0x0 0x2000>,
++			      <0x0 0xfc400000 0x0 0x200000>;
+ 			reg-names = "elbi", "cfg", "config";
+ 			interrupts = <GIC_SPI 221 IRQ_TYPE_LEVEL_HIGH>;
+ 			#interrupt-cells = <1>;
+@@ -134,8 +140,8 @@
+ 			#address-cells = <3>;
+ 			#size-cells = <2>;
+ 			device_type = "pci";
+-			ranges = <0x81000000 0 0 0x0 0xfc600000 0 0x00100000
+-				  0x82000000 0 0xfc700000 0x0 0xfc700000 0 0x1900000>;
++			ranges = <0x81000000 0 0 0x0 0xfc600000 0 0x00100000>,
++				 <0x82000000 0 0xfc700000 0x0 0xfc700000 0 0x1900000>;
+ 
+ 			clocks = <&clkc CLKID_PCIE_PHY
+ 				  &clkc CLKID_PCIE_COMB
+@@ -209,7 +215,7 @@
+ 		};
+ 
+ 		ethmac: ethernet@ff3f0000 {
+-			compatible = "amlogic,meson-axg-dwmac",
++			compatible = "amlogic,meson-g12a-dwmac",
+ 				     "snps,dwmac-3.70a",
+ 				     "snps,dwmac";
+ 			reg = <0x0 0xff3f0000 0x0 0x10000>,
+@@ -282,6 +288,8 @@
+ 				hwrng: rng@218 {
+ 					compatible = "amlogic,meson-rng";
+ 					reg = <0x0 0x218 0x0 0x4>;
++					clocks = <&clkc CLKID_RNG0>;
++					clock-names = "core";
+ 				};
+ 			};
+ 
+@@ -2001,7 +2009,7 @@
+ 				};
+ 			};
+ 
+-			vrtc: rtc@0a8 {
++			vrtc: rtc@a8 {
+ 				compatible = "amlogic,meson-vrtc";
+ 				reg = <0x0 0x000a8 0x0 0x4>;
+ 			};
+@@ -2179,6 +2187,12 @@
+ 				amlogic,channel-interrupts = <64 65 66 67 68 69 70 71>;
+ 			};
+ 
++			watchdog: watchdog@f0d0 {
++				compatible = "amlogic,meson-gxbb-wdt";
++				reg = <0x0 0xf0d0 0x0 0x10>;
++				clocks = <&xtal>;
++			};
++
+ 			spicc0: spi@13000 {
+ 				compatible = "amlogic,meson-g12a-spicc";
+ 				reg = <0x0 0x13000 0x0 0x44>;
+@@ -2303,6 +2317,7 @@
+ 				clocks = <&xtal>, <&clkc CLKID_UART0>, <&xtal>;
+ 				clock-names = "xtal", "pclk", "baud";
+ 				status = "disabled";
++				fifo-size = <128>;
+ 			};
+ 		};
+ 
+@@ -2380,7 +2395,7 @@
+ 				interrupts = <GIC_SPI 30 IRQ_TYPE_LEVEL_HIGH>;
+ 				dr_mode = "host";
+ 				snps,dis_u2_susphy_quirk;
+-				snps,quirk-frame-length-adjustment;
++				snps,quirk-frame-length-adjustment = <0x20>;
+ 				snps,parkmode-disable-ss-quirk;
+ 			};
+ 		};
+diff --git a/arch/arm/dts/meson-g12b.dtsi b/arch/arm/dts/meson-g12b.dtsi
+index 9b8548e5f6e..ee8fcae9f9f 100644
+--- a/arch/arm/dts/meson-g12b.dtsi
++++ b/arch/arm/dts/meson-g12b.dtsi
+@@ -135,3 +135,7 @@
+ 		};
+ 	};
+ };
++
++&mali {
++	dma-coherent;
++};
+-- 
+2.34.0
+

--- a/boards/radxa-zero2/0001-radxa-zero2-board-enablement.patch
+++ b/boards/radxa-zero2/0001-radxa-zero2-board-enablement.patch
@@ -1,0 +1,690 @@
+From d98ead879ae1d6bc168e59dab3ec53a649d5518e Mon Sep 17 00:00:00 2001
+From: Yuntian Zhang <yt@radxa.com>
+Date: Fri, 14 Jan 2022 19:16:39 +0800
+Subject: [PATCH 1/3] boards: amlogic: add Radxa Zero 2 defconfig
+
+Add a defconfig for the Radxa Zero 2 SBC, using Amlogic A311D SoC.
+This file is created manuall based on radxa-zero_defconfig and
+khadas-vim3_defconfig.
+
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+(cherry picked from commit 1df0b2a2f182348ee440aea62c4d9b5776d4e1c7)
+---
+ configs/radxa-zero2_defconfig | 93 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 93 insertions(+)
+ create mode 100644 configs/radxa-zero2_defconfig
+
+diff --git a/configs/radxa-zero2_defconfig b/configs/radxa-zero2_defconfig
+new file mode 100644
+index 00000000000..b4cbc5c37dc
+--- /dev/null
++++ b/configs/radxa-zero2_defconfig
+@@ -0,0 +1,93 @@
++CONFIG_ARM=y
++# CONFIG_SYS_BOARD is not set
++CONFIG_ARCH_MESON=y
++CONFIG_SYS_TEXT_BASE=0x01000000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_ENV_SIZE=0x2000
++CONFIG_DM_GPIO=y
++CONFIG_DEFAULT_DEVICE_TREE="meson-g12b-radxa-zero2"
++CONFIG_MESON_G12A=y
++CONFIG_DEBUG_UART_BASE=0xff803000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_IDENT_STRING=" radxa-zero2"
++CONFIG_DEBUG_UART=y
++CONFIG_OF_BOARD_SETUP=y
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_MISC_INIT_R=y
++# CONFIG_CMD_BDI is not set
++# CONFIG_CMD_IMI is not set
++CONFIG_CMD_GPIO=y
++# CONFIG_CMD_I2C is not set
++# CONFIG_CMD_LOADS is not set
++CONFIG_CMD_MMC=y
++# CONFIG_CMD_PCI is not set
++# CONFIG_CMD_SF_TEST is not set
++# CONFIG_CMD_SPI is not set
++CONFIG_CMD_USB=y
++CONFIG_CMD_USB_MASS_STORAGE=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_REGULATOR=y
++CONFIG_OF_CONTROL=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++# CONFIG_NET_RANDOM_ETHADDR is not set
++# CONFIG_ADC is not set
++# CONFIG_SARADC_MESON is not set
++# CONFIG_BUTTON is not set
++# CONFIG_BUTTON_ADC is not set
++# CONFIG_DM_I2C is not set
++# CONFIG_SYS_I2C_MESON is not set
++CONFIG_MMC_MESON_GX=y
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++# CONFIG_DM_SPI_FLASH is not set
++# CONFIG_SPI_FLASH_WINBOND is not set
++# CONFIG_PHY_REALTEK is not set
++# CONFIG_DM_ETH is not set
++CONFIG_DM_MDIO=y
++CONFIG_DM_MDIO_MUX=y
++# CONFIG_ETH_DESIGNWARE_MESON8B is not set
++CONFIG_MDIO_MUX_MESON_G12A=y
++# CONFIG_NVME is not set
++# CONFIG_PCI is not set
++# CONFIG_PCIE_DW_MESON is not set
++CONFIG_MESON_G12A_USB_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCTRL_MESON_G12A=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MESON_EE_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_RESET=y
++CONFIG_DEBUG_UART_ANNOUNCE=y
++CONFIG_DEBUG_UART_SKIP_INIT=y
++CONFIG_MESON_SERIAL=y
++# CONFIG_SPI is not set
++# CONFIG_DM_SPI is not set
++# CONFIG_MESON_SPIFC is not set
++CONFIG_USB=y
++CONFIG_DM_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_DWC3=y
++# CONFIG_USB_DWC3_GADGET is not set
++CONFIG_USB_DWC3_MESON_G12A=y
++CONFIG_USB_KEYBOARD=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_VENDOR_NUM=0x1b8e
++CONFIG_USB_GADGET_PRODUCT_NUM=0xfada
++CONFIG_USB_GADGET_DWC2_OTG=y
++CONFIG_USB_GADGET_DWC2_OTG_PHY_BUS_WIDTH_8=y
++CONFIG_USB_GADGET_DOWNLOAD=y
++CONFIG_DM_VIDEO=y
++# CONFIG_VIDEO_BPP8 is not set
++# CONFIG_VIDEO_BPP16 is not set
++CONFIG_SYS_WHITE_ON_BLACK=y
++CONFIG_VIDEO_MESON=y
++CONFIG_VIDEO_DT_SIMPLEFB=y
++CONFIG_SPLASH_SCREEN=y
++CONFIG_SPLASH_SCREEN_ALIGN=y
++# CONFIG_VIDEO_BMP_RLE8 is not set
++# CONFIG_BMP_16BPP is not set
++# CONFIG_BMP_24BPP is not set
++# CONFIG_BMP_32BPP is not set
++CONFIG_OF_LIBFDT_OVERLAY=y
+-- 
+2.34.0
+
+
+From caf7d9fb9d81c8d812673573f7a92fbab7747379 Mon Sep 17 00:00:00 2001
+From: Yuntian Zhang <yt@radxa.com>
+Date: Mon, 17 Jan 2022 14:11:14 +0800
+Subject: [PATCH 2/3] ARM: dts: add support for Radxa Zero 2
+
+Import the initial dts from RadxaYuntian/kernel/zero2-bringup repo.
+
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+(cherry picked from commit 28e43804e0f3ff399efc9b42ad5dbdf641923c1b)
+---
+ arch/arm/dts/Makefile                         |   1 +
+ .../dts/meson-g12b-radxa-zero2-u-boot.dtsi    |   7 +
+ arch/arm/dts/meson-g12b-radxa-zero2.dts       | 492 ++++++++++++++++++
+ 3 files changed, 500 insertions(+)
+ create mode 100644 arch/arm/dts/meson-g12b-radxa-zero2-u-boot.dtsi
+ create mode 100644 arch/arm/dts/meson-g12b-radxa-zero2.dts
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index fc16a57e60b..330d6b49bee 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -180,6 +180,7 @@ dtb-$(CONFIG_ARCH_MESON) += \
+ 	meson-g12b-odroid-n2.dtb \
+ 	meson-g12b-odroid-n2-plus.dtb \
+ 	meson-g12b-a311d-khadas-vim3.dtb \
++	meson-g12b-radxa-zero2.dtb \
+ 	meson-sm1-khadas-vim3l.dtb \
+ 	meson-sm1-odroid-c4.dtb \
+ 	meson-sm1-sei610.dtb
+diff --git a/arch/arm/dts/meson-g12b-radxa-zero2-u-boot.dtsi b/arch/arm/dts/meson-g12b-radxa-zero2-u-boot.dtsi
+new file mode 100644
+index 00000000000..236f2468dc2
+--- /dev/null
++++ b/arch/arm/dts/meson-g12b-radxa-zero2-u-boot.dtsi
+@@ -0,0 +1,7 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2019 BayLibre, SAS.
++ * Author: Neil Armstrong <narmstrong@baylibre.com>
++ */
++
++#include "meson-g12-common-u-boot.dtsi"
+diff --git a/arch/arm/dts/meson-g12b-radxa-zero2.dts b/arch/arm/dts/meson-g12b-radxa-zero2.dts
+new file mode 100644
+index 00000000000..be7a1685da0
+--- /dev/null
++++ b/arch/arm/dts/meson-g12b-radxa-zero2.dts
+@@ -0,0 +1,492 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2019 BayLibre, SAS
++ * Author: Neil Armstrong <narmstrong@baylibre.com>
++ * Copyright (c) 2019 Christian Hewitt <christianshewitt@gmail.com>
++ * Copyright (c) 2022 Radxa Limited
++ * Author: Yuntian Zhang <yt@radxa.com>
++ */
++
++/dts-v1/;
++
++#include "meson-g12b-a311d.dtsi"
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/gpio/meson-g12a-gpio.h>
++#include <dt-bindings/sound/meson-g12a-tohdmitx.h>
++
++/ {
++	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
++	model = "Radxa Zero2";
++
++	aliases {
++		serial0 = &uart_AO;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x0 0x0 0x80000000>;
++	};
++
++	gpio-keys-polled {
++		compatible = "gpio-keys-polled";
++		poll-interval = <100>;
++		power-button {
++			label = "power";
++			linux,code = <KEY_POWER>;
++			gpios = <&gpio_ao GPIOAO_3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-green {
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&gpio GPIOA_12 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++	};
++
++	cvbs-connector {
++		status = "disabled";
++		compatible = "composite-video-connector";
++
++		port {
++			cvbs_connector_in: endpoint {
++				remote-endpoint = <&cvbs_vdac_out>;
++			};
++		};
++	};
++
++	hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_connector_in: endpoint {
++				remote-endpoint = <&hdmi_tx_tmds_out>;
++			};
++		};
++	};
++
++	emmc_pwrseq: emmc-pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>;
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&gpio GPIOX_6 GPIO_ACTIVE_LOW>;
++		clocks = <&wifi32k>;
++		clock-names = "ext_clock";
++	};
++
++	ao_5v: regulator-ao_5v {
++		compatible = "regulator-fixed";
++		regulator-name = "AO_5V";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++	};
++
++	vcc_1v8: regulator-vcc_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_3v3>;
++		regulator-always-on;
++	};
++
++	vcc_3v3: regulator-vcc_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++		/* FIXME: actually controlled by VDDCPU_B_EN */
++	};
++
++	vddao_1v8: regulator-vddao_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDIO_AO1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	vddao_3v3: regulator-vddao_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&ao_5v>;
++		regulator-always-on;
++	};
++
++	vddcpu_a: regulator-vddcpu-a {
++		/*
++		 * MP8756GD Regulator.
++		 */
++		compatible = "pwm-regulator";
++
++		regulator-name = "VDDCPU_A";
++		regulator-min-microvolt = <730000>;
++		regulator-max-microvolt = <1010000>;
++
++		pwm-supply = <&ao_5v>;
++
++		pwms = <&pwm_ab 0 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	vddcpu_b: regulator-vddcpu-b {
++		/*
++		 * Silergy SY8120B1ABC Regulator.
++		 */
++		compatible = "pwm-regulator";
++
++		regulator-name = "VDDCPU_B";
++		regulator-min-microvolt = <730000>;
++		regulator-max-microvolt = <1010000>;
++
++		pwm-supply = <&ao_5v>;
++
++		pwms = <&pwm_AO_cd 1 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	sound {
++		compatible = "amlogic,axg-sound-card";
++		model = "RADXA-ZERO2";
++		audio-aux-devs = <&tdmout_b>;
++		audio-routing = "TDMOUT_B IN 0", "FRDDR_A OUT 1",
++				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
++				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
++				"TDM_B Playback", "TDMOUT_B OUT";
++
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++				  <&clkc CLKID_MPLL0>,
++				  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++				       <270950400>,
++				       <393216000>;
++		status = "okay";
++
++		dai-link-0 {
++			sound-dai = <&frddr_a>;
++		};
++
++		dai-link-1 {
++			sound-dai = <&frddr_b>;
++		};
++
++		dai-link-2 {
++			sound-dai = <&frddr_c>;
++		};
++
++		/* 8ch hdmi interface */
++		dai-link-3 {
++			sound-dai = <&tdmif_b>;
++			dai-format = "i2s";
++			dai-tdm-slot-tx-mask-0 = <1 1>;
++			dai-tdm-slot-tx-mask-1 = <1 1>;
++			dai-tdm-slot-tx-mask-2 = <1 1>;
++			dai-tdm-slot-tx-mask-3 = <1 1>;
++			mclk-fs = <256>;
++
++			codec {
++				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_B>;
++			};
++		};
++
++		/* hdmi glue */
++		dai-link-4 {
++			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
++
++			codec {
++				sound-dai = <&hdmi_tx>;
++			};
++		};
++	};
++
++	wifi32k: wifi32k {
++		compatible = "pwm-clock";
++		#clock-cells = <0>;
++		clock-frequency = <32768>;
++		pwms = <&pwm_ef 0 30518 0>; /* PWM_E at 32.768KHz */
++	};
++};
++
++&arb {
++	status = "okay";
++};
++
++&cec_AO {
++	pinctrl-0 = <&cec_ao_a_h_pins>;
++	pinctrl-names = "default";
++	status = "disabled";
++	hdmi-phandle = <&hdmi_tx>;
++};
++
++&cecb_AO {
++	pinctrl-0 = <&cec_ao_b_h_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++	hdmi-phandle = <&hdmi_tx>;
++};
++
++&clkc_audio {
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&vddcpu_b>;
++	operating-points-v2 = <&cpu_opp_table_0>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu1 {
++	cpu-supply = <&vddcpu_b>;
++	operating-points-v2 = <&cpu_opp_table_0>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu100 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu101 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu102 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu103 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cvbs_vdac_port {
++	cvbs_vdac_out: endpoint {
++		remote-endpoint = <&cvbs_connector_in>;
++	};
++};
++
++&frddr_a {
++	status = "okay";
++};
++
++&frddr_b {
++	status = "okay";
++};
++
++&frddr_c {
++	status = "okay";
++};
++
++&gpio {
++	gpio-line-names =
++		/* GPIOZ */
++		"PIN_27", "PIN_28", "PIN_7", "PIN_11", "PIN_13", "PIN_15", "PIN_18", "PIN_40",
++		"", "", "", "", "", "", "", "",
++		/* GPIOH */
++		"", "", "", "", "PIN_19", "PIN_21", "PIN_24", "PIN_23",
++		"",
++		/* BOOT */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "EMMC_PWRSEQ", "", "", "",
++		/* GPIOC */
++		"", "", "", "", "", "", "SD_CD", "PIN_36",
++		/* GPIOA */
++		"PIN_32", "PIN_12", "PIN_35", "", "", "PIN_38", "", "",
++		"", "", "", "", "LED_GREEN", "PIN_31", "PIN_3", "PIN_5",
++		/* GPIOX */
++		"", "", "", "", "", "", "SDIO_PWRSEQ", "",
++		"", "", "", "", "", "", "", "",
++		"", "BT_SHUTDOWN", "", "";
++};
++
++&gpio_ao {
++	gpio-line-names =
++		/* GPIOAO */
++		"PIN_8", "PIN_10", "", "BTN_POWER", "", "", "", "PIN_29",
++		"PIN_33", "PIN_37", "FAN", "",
++		/* GPIOE */
++		"", "", "";
++};
++
++&hdmi_tx {
++	status = "okay";
++	pinctrl-0 = <&hdmitx_hpd_pins>, <&hdmitx_ddc_pins>;
++	pinctrl-names = "default";
++	hdmi-supply = <&ao_5v>;
++};
++
++&hdmi_tx_tmds_port {
++	hdmi_tx_tmds_out: endpoint {
++		remote-endpoint = <&hdmi_connector_in>;
++	};
++};
++
++&ir {
++	status = "disabled";
++	pinctrl-0 = <&remote_input_ao_pins>;
++	pinctrl-names = "default";
++};
++
++&pwm_ab {
++	pinctrl-0 = <&pwm_a_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin0";
++	status = "okay";
++};
++
++&pwm_ef {
++	pinctrl-0 = <&pwm_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin2";
++	status = "okay";
++};
++
++&pwm_AO_cd {
++	pinctrl-0 = <&pwm_ao_d_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin4";
++	status = "okay";
++};
++
++&saradc {
++	status = "okay";
++	vref-supply = <&vddao_1v8>;
++};
++
++/* SDIO */
++&sd_emmc_a {
++	status = "okay";
++	pinctrl-0 = <&sdio_pins>;
++	pinctrl-1 = <&sdio_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	bus-width = <4>;
++	cap-sd-highspeed;
++	max-frequency = <100000000>;
++
++	non-removable;
++	disable-wp;
++
++	/* WiFi firmware requires power to be kept while in suspend */
++	keep-power-in-suspend;
++
++	mmc-pwrseq = <&sdio_pwrseq>;
++
++	vmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddao_1v8>;
++
++	brcmf: wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++	};
++};
++
++/* SD card */
++&sd_emmc_b {
++	status = "okay";
++	pinctrl-0 = <&sdcard_c_pins>;
++	pinctrl-1 = <&sdcard_clk_gate_c_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <4>;
++	cap-sd-highspeed;
++	max-frequency = <50000000>;
++	disable-wp;
++
++	cd-gpios = <&gpio GPIOC_6 GPIO_ACTIVE_LOW>;
++	vmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddao_3v3>;
++};
++
++/* eMMC */
++&sd_emmc_c {
++	status = "okay";
++	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_8b_pins>, <&emmc_ds_pins>;
++	pinctrl-1 = <&emmc_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
++	max-frequency = <200000000>;
++	disable-wp;
++
++	mmc-pwrseq = <&emmc_pwrseq>;
++	vmmc-supply = <&vcc_3v3>;
++	vqmmc-supply = <&vcc_1v8>;
++};
++
++&tdmif_b {
++	status = "okay";
++};
++
++&tdmout_b {
++	status = "okay";
++};
++
++&tohdmitx {
++	status = "okay";
++};
++
++&uart_A {
++	status = "okay";
++	pinctrl-0 = <&uart_a_pins>, <&uart_a_cts_rts_pins>;
++	pinctrl-names = "default";
++	uart-has-rtscts;
++
++	bluetooth {
++		compatible = "brcm,bcm43438-bt";
++		shutdown-gpios = <&gpio GPIOX_17 GPIO_ACTIVE_HIGH>;
++		max-speed = <2000000>;
++		clocks = <&wifi32k>;
++		clock-names = "lpo";
++	};
++};
++
++&usb {
++	status = "okay";
++};
+-- 
+2.34.0
+
+
+From ff315b4b63ef6d7ffb3eea7c1996df23b3911937 Mon Sep 17 00:00:00 2001
+From: Yuntian Zhang <yt@radxa.com>
+Date: Thu, 20 Jan 2022 17:19:11 +0800
+Subject: [PATCH 3/3] boards: enable vidconsole and usbkbd for Radxa Zero 2
+
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+(cherry picked from commit f21fc0a44c33cc33df5beaa00f3093c36c975829)
+---
+ configs/radxa-zero2_defconfig | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configs/radxa-zero2_defconfig b/configs/radxa-zero2_defconfig
+index b4cbc5c37dc..010efbdc9a9 100644
+--- a/configs/radxa-zero2_defconfig
++++ b/configs/radxa-zero2_defconfig
+@@ -6,6 +6,8 @@ CONFIG_NR_DRAM_BANKS=1
+ CONFIG_ENV_SIZE=0x2000
+ CONFIG_DM_GPIO=y
+ CONFIG_DEFAULT_DEVICE_TREE="meson-g12b-radxa-zero2"
++CONFIG_USE_PREBOOT=y
++CONFIG_PREBOOT="usb start"
+ CONFIG_MESON_G12A=y
+ CONFIG_DEBUG_UART_BASE=0xff803000
+ CONFIG_DEBUG_UART_CLOCK=24000000
+-- 
+2.34.0
+

--- a/boards/radxa-zero2/default.nix
+++ b/boards/radxa-zero2/default.nix
@@ -55,6 +55,7 @@ in
     defconfig = "radxa-zero2_defconfig";
     patches = [
       ./0001-radxa-zero2-board-enablement.patch
+      ./0001-arch-arm-dts-Sync-amlogic-meson-DT-with-mainline.patch
     ];
     builder.additionalArguments = {
       FIPDIR = "${radxa-fip}/radxa-zero2";

--- a/boards/radxa-zero2/default.nix
+++ b/boards/radxa-zero2/default.nix
@@ -1,0 +1,63 @@
+{ lib, pkgs, ... }:
+
+let
+  # TODO: remove once imported in the LibreELEC FIP frmware packages
+  #       alternatively reconsider how we handle vendor-provided blobs?
+  radxa-fip = pkgs.callPackage (
+    { stdenv
+    , lib
+    , fetchpatch
+    , fetchFromGitHub
+    }:
+
+    stdenv.mkDerivation {
+      pname = "radxa-fip";
+      version = "2022-01-24";
+
+      src = fetchFromGitHub {
+        owner = "radxa";
+        repo = "fip";
+        rev = "4e7cacb68682bf2223974895d8e0d6368beac101";
+        sha256 = "sha256-QZ1tqQpnvWrYrkxik3S9dXa0+KqmsH8huFqkw2iyOBk=";
+      };
+
+      installPhase = ''
+        # We're lazy... this will allow us to *just* copy everything in $out
+        rm -v LICENSE README.md
+        # Remove unneeded files; we're not re-using the downstream build infra.
+        rm -v Makefile
+        mkdir -p $out
+        mv -t $out/ *
+      '';
+
+      dontFixup = true;
+
+      meta = with lib; {
+        description = "Firmware Image Package (FIP) sources used to sign Amlogic U-Boot binaries";
+        license = licenses.unfreeRedistributableFirmware;
+        maintainers = with maintainers; [ samueldr ];
+      };
+    }
+  ) { };
+in
+{
+  device = {
+    manufacturer = "Radxa";
+    name = "Zero 2";
+    identifier = "radxa-zero2";
+  };
+
+  hardware = {
+    soc = "amlogic-a311d";
+  };
+
+  Tow-Boot = {
+    defconfig = "radxa-zero2_defconfig";
+    patches = [
+      ./0001-radxa-zero2-board-enablement.patch
+    ];
+    builder.additionalArguments = {
+      FIPDIR = "${radxa-fip}/radxa-zero2";
+    };
+  };
+}

--- a/modules/hardware/amlogic/default.nix
+++ b/modules/hardware/amlogic/default.nix
@@ -16,6 +16,7 @@ let
   #
 
   amlogicG12 = lib.any (soc: config.hardware.socs.${soc}.enable) [
+    "amlogic-a311d"
     "amlogic-s922x"
   ];
   amlogicGXL = lib.any (soc: config.hardware.socs.${soc}.enable) [
@@ -32,6 +33,12 @@ in
 {
   options = {
     hardware.socs = {
+      amlogic-a311d.enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable when SoC is Amlogic A311D";
+        internal = true;
+      };
       amlogic-s805x.enable = mkOption {
         type = types.bool;
         default = false;
@@ -56,11 +63,15 @@ in
   config = mkMerge [
     {
       hardware.socList = [
+        "amlogic-a311d"
         "amlogic-s805x"
         "amlogic-s905"
         "amlogic-s922x"
       ];
     }
+    (mkIf cfg.amlogic-a311d.enable {
+      system.system = "aarch64-linux";
+    })
     (mkIf cfg.amlogic-s805x.enable {
       system.system = "aarch64-linux";
     })

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -40,6 +40,7 @@ in
             # Intrusive opinionated patches
             (base + "/0001-Tow-Boot-sunxi-ignore-mmc_auto-force-SD-then-eMMC.patch")
             (base + "/0001-Revert-rockchip-Fix-MMC-boot-order.patch")
+            (base + "/0001-meson-Prefer-eMMC-to-SD-card-boot.patch")
           ];
         };
       in

--- a/support/u-boot/2021.10/patches/0001-Tow-Boot-Provide-opinionated-boot-flow.patch
+++ b/support/u-boot/2021.10/patches/0001-Tow-Boot-Provide-opinionated-boot-flow.patch
@@ -40,7 +40,7 @@ new file mode 100644
 index 0000000000..284667ab8e
 --- /dev/null
 +++ b/include/tow-boot_env.h
-@@ -0,0 +1,57 @@
+@@ -0,0 +1,58 @@
 +#ifndef _TOW_BOOT_ENV_H
 +#define _TOW_BOOT_ENV_H
 +
@@ -65,6 +65,7 @@ index 0000000000..284667ab8e
 +	"bootcmd=run setup_leds; run distro_bootcmd\0" \
 +	"target_name_mmc0=" CONFIG_TOW_BOOT_MMC0_NAME "\0" \
 +	"target_name_mmc1=" CONFIG_TOW_BOOT_MMC1_NAME "\0" \
++	"target_name_mmc2=" CONFIG_TOW_BOOT_MMC2_NAME "\0" \
 +	"target_name_usb0=USB\0" \
 +	"target_name_nvme0=NVME\0" \
 +	"target_name_pxe=PXE\0" \

--- a/support/u-boot/2021.10/patches/0001-meson-Prefer-eMMC-to-SD-card-boot.patch
+++ b/support/u-boot/2021.10/patches/0001-meson-Prefer-eMMC-to-SD-card-boot.patch
@@ -1,0 +1,26 @@
+From 845d1ef559cdca814eee4fcff215a18b22b18909 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Sat, 12 Feb 2022 13:53:12 -0500
+Subject: [PATCH] meson: Prefer eMMC to SD card boot
+
+---
+ include/configs/meson64.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/configs/meson64.h b/include/configs/meson64.h
+index f9bb0240d2c..a5753b14c5e 100644
+--- a/include/configs/meson64.h
++++ b/include/configs/meson64.h
+@@ -69,8 +69,8 @@
+ #ifndef BOOT_TARGET_DEVICES
+ #define BOOT_TARGET_DEVICES(func) \
+ 	func(ROMUSB, romusb, na)  \
+-	func(MMC, mmc, 0) \
+ 	func(MMC, mmc, 1) \
++	func(MMC, mmc, 0) \
+ 	func(MMC, mmc, 2) \
+ 	BOOT_TARGET_DEVICES_USB(func) \
+ 	BOOT_TARGET_NVME(func) \
+-- 
+2.34.0
+

--- a/support/u-boot/2021.10/patches/0001-tow-boot-menu.patch
+++ b/support/u-boot/2021.10/patches/0001-tow-boot-menu.patch
@@ -105,14 +105,14 @@ index 0000000000..8666636672
 +
 +config TOW_BOOT_MMC0_NAME
 +	string "MMC0 user-friendly name"
-+	default "SD" if ARCH_SUNXI
++	default "SD" if ARCH_SUNXI || MESON_G12A
 +	default "eMMC"
 +	help
 +	  Name used in the interface for MMC0
 +
 +config TOW_BOOT_MMC1_NAME
 +	string "MMC1 user-friendly name"
-+	default "eMMC" if ARCH_SUNXI
++	default "eMMC" if ARCH_SUNXI || MESON_G12A
 +	default "SD"
 +	help
 +	  Name used in the interface for MMC1

--- a/support/u-boot/2021.10/patches/0001-tow-boot-menu.patch
+++ b/support/u-boot/2021.10/patches/0001-tow-boot-menu.patch
@@ -83,7 +83,7 @@ new file mode 100644
 index 0000000000..8666636672
 --- /dev/null
 +++ b/cmd/tow-boot/Kconfig
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,40 @@
 +menu "Tow-Boot additional commands"
 +
 +config TOW_BOOT_MENU
@@ -116,6 +116,12 @@ index 0000000000..8666636672
 +	default "SD"
 +	help
 +	  Name used in the interface for MMC1
++
++config TOW_BOOT_MMC2_NAME
++	string "MMC2 user-friendly name"
++	default "(Unused)"
++	help
++	  Name used in the interface for MMC2
 +
 +endmenu
 diff --git a/cmd/tow-boot/Makefile b/cmd/tow-boot/Makefile


### PR DESCRIPTION
This adds support for the [Radxa Zero 2](https://wiki.radxa.com/Zero2).

This also adds the required Amlogic A311D support.

This family of board has *three* possible `MMC[0-2]` values it could be using, thus the support for naming MMC interfaces had to be updated to allow naming `MMC2`.

Thus this change also shows how to edit the naming of MMC interfaces for boards having weirder setups.

* * *

At this point in time, *mmc boot* support is not implemented, but it is coming in a further WIP change. MMC boot support is not strictly required for adding the port to Tow-Boot.

This can currently be used from eMMC or SD card.

### Tested:

 - HDMI output
 - USB input (seems to exhibit the same issues as other amlogic boards, which is good I guess. Namely, some "menu input events" may need to be "pumped out" by pressing CTRL a couple of times if it seems to not respond.)
 - Synced amlogic DTs with mainline, though other than "improved" 5.16 compatibility, I expect nothing really matters.
 - The latest NixOS UEFI "new kernel" iso boots, though it seems there might be some form of graphical issues... Highly likely to not be relevant to Tow-Boot.
     - (Slightly unrelated: Installed NixOS UEFI iso with "current LTS" (5.10) stock and it is alright, no weird rendering issues. Though it shows the innate FDT is alright.)

* * *

5117f6b73cd988ef14d20e575eb41a09a98c2a93 Handles #92 for Amlogic (hopefully correctly for all vintages... otherwise we'll need to make this configurable.)

* * *

cc @RadxaYuntian