### PR TITLE
Add Odroid N2+ support

### DIFF
--- a/boards/odroid-N2-plus/0001-Enable-the-SPI-on-the-ODROID-N2-by-default.patch
+++ b/boards/odroid-N2-plus/0001-Enable-the-SPI-on-the-ODROID-N2-by-default.patch
@@ -1,0 +1,57 @@
+From 367dfbebd1099f7c3d58ee1da007653f34fb0f69 Mon Sep 17 00:00:00 2001
+From: Las <las@protonmail.ch>
+Date: Wed, 16 Jun 2021 12:28:17 +0000
+Subject: [PATCH] Enable the SPI on the ODROID N2 by default
+
+This halves the the bandwidth to the eMMC, but given
+that this will apparently be restored when booting a kernel with the
+default device tree, it isn't really important.
+---
+ arch/arm/dts/meson-g12b-odroid-n2.dtsi | 6 +++---
+ configs/odroid-n2_defconfig            | 6 ++++++
+ 2 files changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/dts/meson-g12b-odroid-n2.dtsi b/arch/arm/dts/meson-g12b-odroid-n2.dtsi
+index 6982632ae6..ef77b1c77f 100644
+--- a/arch/arm/dts/meson-g12b-odroid-n2.dtsi
++++ b/arch/arm/dts/meson-g12b-odroid-n2.dtsi
+@@ -515,11 +515,11 @@
+ /* eMMC */
+ &sd_emmc_c {
+ 	status = "okay";
+-	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_8b_pins>, <&emmc_ds_pins>;
++	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_4b_pins>, <&emmc_ds_pins>;
+ 	pinctrl-1 = <&emmc_clk_gate_pins>;
+ 	pinctrl-names = "default", "clk-gate";
+ 
+-	bus-width = <8>;
++	bus-width = <4>;
+ 	cap-mmc-highspeed;
+ 	mmc-ddr-1_8v;
+ 	mmc-hs200-1_8v;
+@@ -539,7 +539,7 @@
+  * The SW1 slide should also be set to the correct position.
+  */
+ &spifc {
+-	status = "disabled";
++	status = "okay";
+ 	pinctrl-0 = <&nor_pins>;
+ 	pinctrl-names = "default";
+ 
+diff --git a/configs/odroid-n2_defconfig b/configs/odroid-n2_defconfig
+index 8a12148fb4..d02bae4feb 100644
+--- a/configs/odroid-n2_defconfig
++++ b/configs/odroid-n2_defconfig
+@@ -71,3 +71,9 @@ CONFIG_BMP_16BPP=y
+ CONFIG_BMP_24BPP=y
+ CONFIG_BMP_32BPP=y
+ CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_CMD_SPI=y
++CONFIG_DM_SPI_FLASH=y
++CONFIG_SPI_FLASH_MACRONIX=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MESON_SPIFC=y
+-- 
+2.31.1
+

--- a/boards/odroid-N2-plus/default.nix
+++ b/boards/odroid-N2-plus/default.nix
@@ -1,0 +1,32 @@
+{ lib, pkgs, ... }:
+
+{
+  device = {
+    manufacturer = "ODROID";
+    name = "N2-plus";
+    identifier = "odroid-N2-plus";
+  };
+
+  hardware = {
+    soc = "amlogic-s922x";
+    SPISize = 8 * 1024 * 1024;
+  };
+
+  Tow-Boot = {
+    defconfig = "odroid-n2_defconfig";
+    config = [
+      (helpers: with helpers; {
+        USE_PREBOOT = yes;
+        PREBOOT = freeform ''"usb start ; usb info"'';
+        CONFIG_DEFAULT_DEVICE_TREE = freeform ''"meson-g12b-odroid-n2-plus"'';
+      })
+    ];
+    patches = [
+      # ODROID N2 SPI support
+      ./0001-Enable-the-SPI-on-the-ODROID-N2-by-default.patch
+    ];
+    builder.additionalArguments = {
+      FIPDIR = "${pkgs.Tow-Boot.amlogicFirmware}/odroid-n2";
+    };
+  };
+}


### PR DESCRIPTION
The Odroid N2+ is almost the same device as the regular N2, except that it
supports some other clock speeds.

So change the default dts to the N2+ one so we can make use of those.

While N2 dts works on the N2+, an N2+ dts can be dangerous on the N2.

PS: I don't know how Nix scipts work, but I tried just copying from the Odroid N2 board folder and make the slight change that was needed there. If something is wrong please let me know.

Signed-off-by: Dan Johansen <strit@manjaro.org>