### PR TITLE
Doc: Distributions: Add Manjaro ARM

### DIFF
--- a/doc/distributions/manjaro.md
+++ b/doc/distributions/manjaro.md
@@ -1,5 +1,5 @@
 Manjaro
------
+=======
 
 Notes specific to Manjaro.
 

--- a/doc/distributions/manjaro.md
+++ b/doc/distributions/manjaro.md
@@ -1,0 +1,20 @@
+Manjaro
+-----
+
+Notes specific to Manjaro.
+
+## Installation of Manjaro on a device with Tow-Boot on SPI
+
+This guide only covers this use case for now, as the regular Manjaro ARM images for the devices they support, already ships with U-boot on the pre-made image.
+
+Booting Manjaro on a device that already has Tow-Boot on the SPI flash is really easy.
+
+While any of the device specific images should still boot just fine with Tow-Boot, Manjaro recently started created **Generic Aarch64** images for testing with SPI installations.
+
+These can be found on [github](https://github.com/manjaro-arm/generic-images/releases) at the moment, since it's still in early development and not many devices have been tested yet.
+
+The generic image uses Extlinux to boot the kernel and, as such, is not UEFI capable.
+
+## Installation of Manjaro via UEFI
+
+Currently not supported.

--- a/doc/distributions/manjaro.md
+++ b/doc/distributions/manjaro.md
@@ -3,18 +3,10 @@ Manjaro
 
 Notes specific to Manjaro.
 
-## Installation of Manjaro on a device with Tow-Boot on SPI
+## Supported booting mechanisms
 
-This guide only covers this use case for now, as the regular Manjaro ARM images for the devices they support, already ships with U-boot on the pre-made image.
+The Manjaro ARM Generic images only supports booting with the Extlinux schema at this stage.
 
-Booting Manjaro on a device that already has Tow-Boot on the SPI flash is really easy.
+See [instructions on Manjaro wiki](https://wiki.manjaro.org/index.php/Manjaro-ARM#Preparing_the_SPI_.28optional.29)
 
-While any of the device specific images should still boot just fine with Tow-Boot, Manjaro recently started created **Generic Aarch64** images for testing with SPI installations.
-
-These can be found on [github](https://github.com/manjaro-arm/generic-images/releases) at the moment, since it's still in early development and not many devices have been tested yet.
-
-The generic image uses Extlinux to boot the kernel and, as such, is not UEFI capable.
-
-## Installation of Manjaro via UEFI
-
-Currently not supported.
+Booting via UEFI is not supported yet, but is being worked on.

--- a/doc/installing-an-operating-system.md
+++ b/doc/installing-an-operating-system.md
@@ -17,5 +17,6 @@ Linux
 <!-- This list is **alphabetically ordered** -->
 
  - [Fedora](distributions/fedora.md)
+ - [Manjaro](distributions/manjaro.md)
  - [NixOS](distributions/nixos.md)
- * [Manjaro](distributions/manjaro.md)
+

--- a/doc/installing-an-operating-system.md
+++ b/doc/installing-an-operating-system.md
@@ -18,3 +18,4 @@ Linux
 
  - [Fedora](distributions/fedora.md)
  - [NixOS](distributions/nixos.md)
+ * [Manjaro](distributions/manjaro.md)


### PR DESCRIPTION
This is the first iteration of documentation on how to install Manjaro on a device with Tow-Boot.

So far only Tow-Boot on SPI is described and UEFI not supported yet.

Signed-off-by: Dan Johansen <strit@manjaro.org>