### PR TITLE
release.nix: Fix archive names in result output

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -50,7 +50,7 @@ in
     ${concatStringsSep "\n" (builtins.map (eval: ''
       (
       echo " :: Packaging ${eval.config.device.identifier}"
-      cp -t $out/ ${eval.build.archive}
+      cp ${eval.build.archive} $out/${eval.build.archive.name}
       )
     '') releasedEvals)}
   ''


### PR DESCRIPTION
From:

```
 ~/.../Tow-Boot/Tow-Boot 130 $ ll result/                                                                                              
total 398260                                                                                                                                   
-r--r--r-- 1 root root 31268788 Dec 31  1969 2zx71yr6ak4wg7yb64ypj7m4akczi99x-radxa-RockPi4-2021.10-004-pre.tar.xz                             
-r--r--r-- 1 root root 31272620 Dec 31  1969 4sy1kvrnwl13xwqr89a1snhpdk8815dy-radxa-RockPi4C-2021.10-004-pre.tar.xz                            
-r--r--r-- 1 root root 15094020 Dec 31  1969 7x66ngcihcws3gdiwx06vg3d39s21lsf-orangePi-pc-2021.10-004-pre.tar.xz                               
-r--r--r-- 1 root root 15134312 Dec 31  1969 839iyyqdfq742hv04b64dqfbcawv6c79-pine64-pineA64-2021.10-004-pre.tar.xz                            
-r--r--r-- 1 root root 31670644 Dec 31  1969 b0lkxxp2ly6hdbc6ksksfnkhriz2gdp7-libreComputer-rocRk3399PcMezzanine-2021.10-004-pre.tar.xz        
-r--r--r-- 1 root root 30295724 Dec 31  1969 by7lqpjnmmh5n4ik46llr1g35r4bwwxi-pine64-pineA64LTS-2021.10-004-pre.tar.xz                         
-r--r--r-- 1 root root 15151144 Dec 31  1969 cvl0qy5q3sqd08pj6jvb6ivl9lk0nlar-pine64-pinebookA64-2021.10-004-pre.tar.xz                        
-r--r--r-- 1 root root 15154120 Dec 31  1969 fiysnv27n9pfmc0bm5553a98bkh0vpks-orangePi-zeroPlus2H5-2021.10-004-pre.tar.xz                      
-r--r--r-- 1 root root 15129244 Dec 31  1969 j5qp6a1scxxzi4jymi4crp8rjaw2zgr1-olimex-teresI-2021.10-004-pre.tar.xz                             
-r--r--r-- 1 root root 19668012 Dec 31  1969 jmgq1clvknr4l7zdxi8syilhhv372wma-raspberryPi-aarch64-2021.10-004-pre.tar.xz                       
-r--r--r-- 1 root root 31272164 Dec 31  1969 k0l1wb43fw95jlp7djicmpd6nm8n0xc1-pine64-pinebookPro-2021.10-004-pre.tar.xz                        
-r--r--r-- 1 root root 15328624 Dec 31  1969 mjkmcj99h2405878r180nsq4dvxmmpkr-radxa-zero2-2021.10-004-pre.tar.xz                               
-r--r--r-- 1 root root 15137400 Dec 31  1969 nbwbp56m6kciqy8yzrv4lfb43v5f1b8h-odroid-C2-2021.10-004-pre.tar.xz                                 
-r--r--r-- 1 root root 30662408 Dec 31  1969 npghzbs6plyvh7q3byacq56mjhfi3zzs-odroid-N2-2021.10-004-pre.tar.xz                                 
-r--r--r-- 1 root root 32881348 Dec 31  1969 nsmvydysa39f5vs9y0bh9y017sj0ibnb-libreComputer-amlS805xAc-2021.10-004-pre.tar.xz                  
-r--r--r-- 1 root root 31237528 Dec 31  1969 qj8lkx7p4fqrzvkx1f71s36936nqc7yz-pine64-rockpro64-2021.10-004-pre.tar.xz                          
-r--r--r-- 1 root root 31372200 Dec 31  1969 zlbmbcx925kxix0nakysx12sk8g6byhp-libreComputer-rocRk3399Pc-2021.10-004-pre.tar.xz                 
```

To:

```
 ~/.../Tow-Boot/Tow-Boot $ ll result/                          
total 398252                                                           
-r--r--r-- 1 root root 32881348 Dec 31  1969 libreComputer-amlS805xAc-2021.10-004-pre.tar.xz                                                   
-r--r--r-- 1 root root 31372200 Dec 31  1969 libreComputer-rocRk3399Pc-2021.10-004-pre.tar.xz                                                  
-r--r--r-- 1 root root 31670644 Dec 31  1969 libreComputer-rocRk3399PcMezzanine-2021.10-004-pre.tar.xz                                         
-r--r--r-- 1 root root 15137400 Dec 31  1969 odroid-C2-2021.10-004-pre.tar.xz                                                                  
-r--r--r-- 1 root root 30662408 Dec 31  1969 odroid-N2-2021.10-004-pre.tar.xz                                                                  
-r--r--r-- 1 root root 15129244 Dec 31  1969 olimex-teresI-2021.10-004-pre.tar.xz                                                              
-r--r--r-- 1 root root 15094020 Dec 31  1969 orangePi-pc-2021.10-004-pre.tar.xz                                                                
-r--r--r-- 1 root root 15154120 Dec 31  1969 orangePi-zeroPlus2H5-2021.10-004-pre.tar.xz
-r--r--r-- 1 root root 15134312 Dec 31  1969 pine64-pineA64-2021.10-004-pre.tar.xz
-r--r--r-- 1 root root 30295724 Dec 31  1969 pine64-pineA64LTS-2021.10-004-pre.tar.xz
-r--r--r-- 1 root root 15151144 Dec 31  1969 pine64-pinebookA64-2021.10-004-pre.tar.xz
-r--r--r-- 1 root root 31272164 Dec 31  1969 pine64-pinebookPro-2021.10-004-pre.tar.xz
-r--r--r-- 1 root root 31237528 Dec 31  1969 pine64-rockpro64-2021.10-004-pre.tar.xz
-r--r--r-- 1 root root 31268788 Dec 31  1969 radxa-RockPi4-2021.10-004-pre.tar.xz
-r--r--r-- 1 root root 31272620 Dec 31  1969 radxa-RockPi4C-2021.10-004-pre.tar.xz
-r--r--r-- 1 root root 15328624 Dec 31  1969 radxa-zero2-2021.10-004-pre.tar.xz
-r--r--r-- 1 root root 19668012 Dec 31  1969 raspberryPi-aarch64-2021.10-004-pre.tar.xz
```