### PR TITLE
odroid-N2: increase default SPI speed so flash read/write works properly

### DIFF
--- a/boards/odroid/default.nix
+++ b/boards/odroid/default.nix
@@ -14,6 +14,7 @@
     extraConfig = ''
       CONFIG_USE_PREBOOT=y
       CONFIG_PREBOOT="usb start ; usb info"
+      CONFIG_SF_DEFAULT_SPEED=52000000
     '';
 
   };


### PR DESCRIPTION
It turns out the default `sf` flash command access speed of 1MHz prevents the onboard flash chip from working properly for whatever reason. This patch increases the speed to 52MHz (somewhat arbitrarily selected as half the 104MHz max speed of the chip) and now it can be read and written properly.

This fixes #103 . I can flash the SPI using the menu in the installer image, then boot off the SPI flash, and use that Tow-Boot to boot off an attached eMMC.

I will do a bit more testing and investigation and submit this upstream at some point.