### PR TITLE
Add product page URLs

### DIFF
--- a/boards/libreComputer-amlS805xAc/default.nix
+++ b/boards/libreComputer-amlS805xAc/default.nix
@@ -5,6 +5,7 @@
     manufacturer = "Libre Computer";
     name = "La Frite";
     identifier = "libreComputer-amlS805xAc";
+    productPageURL = "https://libre.computer/products/s805x/";
   };
 
   hardware = {

--- a/boards/libreComputer-rocRk3399Pc/default.nix
+++ b/boards/libreComputer-rocRk3399Pc/default.nix
@@ -5,6 +5,7 @@
     manufacturer = "Libre Computer";
     name = "Renegade Elite";
     identifier = lib.mkDefault "libreComputer-rocRk3399Pc";
+    productPageURL = "https://libre.computer/products/rk3399/";
   };
 
   hardware = {

--- a/boards/odroid-C2/default.nix
+++ b/boards/odroid-C2/default.nix
@@ -14,6 +14,7 @@
     manufacturer = "ODROID";
     name = "C2";
     identifier = "odroid-C2";
+    productPageURL = "https://www.hardkernel.com/shop/odroid-c2/";
   };
 
   hardware = {

--- a/boards/odroid-N2/default.nix
+++ b/boards/odroid-N2/default.nix
@@ -5,6 +5,7 @@
     manufacturer = "ODROID";
     name = "N2";
     identifier = "odroid-N2";
+    productPageURL = "https://www.hardkernel.com/shop/odroid-n2-with-4gbyte-ram-2/";
   };
 
   hardware = {

--- a/boards/olimex-teresI/default.nix
+++ b/boards/olimex-teresI/default.nix
@@ -3,6 +3,7 @@
     manufacturer = "Olimex";
     name = "TERES-I";
     identifier = "olimex-teresI";
+    productPageURL = "https://www.olimex.com/Products/DIY-Laptop/KITS/TERES-A64-BLACK/open-source-hardware";
   };
 
   hardware = {

--- a/boards/orangePi-pc/default.nix
+++ b/boards/orangePi-pc/default.nix
@@ -3,6 +3,7 @@
     manufacturer = "Orange Pi";
     name = "PC";
     identifier = "orangePi-pc";
+    productPageURL = "http://www.orangepi.org/orangepipc/";
   };
 
   hardware = {

--- a/boards/orangePi-zeroPlus2H5/default.nix
+++ b/boards/orangePi-zeroPlus2H5/default.nix
@@ -3,6 +3,7 @@
     manufacturer = "Orange Pi";
     name = "Zero Plus2 (H5)";
     identifier = "orangePi-zeroPlus2H5";
+    productPageURL = "http://www.orangepi.org/OrangePiZeroPlus2/";
   };
 
   hardware = {

--- a/boards/pine64-pineA64/default.nix
+++ b/boards/pine64-pineA64/default.nix
@@ -3,6 +3,7 @@
     manufacturer = "PINE64";
     name = "A64";
     identifier = "pine64-pineA64";
+    productPageURL = "https://www.pine64.org/devices/single-board-computers/pine-a64/";
   };
 
   hardware = {

--- a/boards/pine64-pineA64LTS/default.nix
+++ b/boards/pine64-pineA64LTS/default.nix
@@ -3,6 +3,7 @@
     manufacturer = "PINE64";
     name = "A64-LTS";
     identifier = "pine64-pineA64LTS";
+    productPageURL = "https://www.pine64.org/devices/single-board-computers/pine-a64-lts/";
   };
 
   hardware = {

--- a/boards/pine64-pinebookA64/default.nix
+++ b/boards/pine64-pinebookA64/default.nix
@@ -3,6 +3,7 @@
     manufacturer = "PINE64";
     name = "Pinebook (A64)";
     identifier = "pine64-pinebookA64";
+    productPageURL = "https://www.pine64.org/pinebook/";
   };
 
   hardware = {

--- a/boards/pine64-pinebookPro/default.nix
+++ b/boards/pine64-pinebookPro/default.nix
@@ -5,6 +5,7 @@
     manufacturer = "PINE64";
     name = "Pinebook Pro";
     identifier = "pine64-pinebookPro";
+    productPageURL = "https://www.pine64.org/pinebook-pro/";
   };
 
   hardware = {

--- a/boards/pine64-pinephoneA64/default.nix
+++ b/boards/pine64-pinephoneA64/default.nix
@@ -12,6 +12,7 @@ in
     manufacturer = "PINE64";
     name = "Pinephone (A64)";
     identifier = "pine64-pinephoneA64";
+    productPageURL = "https://www.pine64.org/pinephone/";
   };
 
   hardware = {

--- a/boards/pine64-pinephonePro/default.nix
+++ b/boards/pine64-pinephonePro/default.nix
@@ -5,6 +5,7 @@
     manufacturer = "PINE64";
     name = "Pinephone Pro";
     identifier = "pine64-pinephonePro";
+    productPageURL = "https://www.pine64.org/pinephonepro/";
   };
 
   hardware = {

--- a/boards/pine64-rockpro64/default.nix
+++ b/boards/pine64-rockpro64/default.nix
@@ -3,6 +3,7 @@
     manufacturer = "PINE64";
     name = "ROCKPro64";
     identifier = "pine64-rockpro64";
+    productPageURL = "https://www.pine64.org/rockpro64/";
   };
 
   hardware = {

--- a/boards/radxa-RockPi4/default.nix
+++ b/boards/radxa-RockPi4/default.nix
@@ -5,6 +5,7 @@
     manufacturer = "Radxa";
     name = lib.mkDefault "ROCK Pi 4 model A/B";
     identifier = lib.mkDefault "radxa-RockPi4";
+    productPageURL = "https://wiki.radxa.com/Rockpi4";
   };
 
   hardware = {

--- a/boards/radxa-zero2/default.nix
+++ b/boards/radxa-zero2/default.nix
@@ -45,6 +45,7 @@ in
     manufacturer = "Radxa";
     name = "Zero 2";
     identifier = "radxa-zero2";
+    productPageURL = "https://wiki.radxa.com/Zero2";
   };
 
   hardware = {

--- a/boards/raspberryPi-aarch64/default.nix
+++ b/boards/raspberryPi-aarch64/default.nix
@@ -38,6 +38,7 @@ in
     manufacturer = "Raspberry Pi";
     name = "Combined AArch64";
     identifier = lib.mkDefault "raspberryPi-aarch64";
+    productPageURL = "https://www.raspberrypi.com/products/";
   };
 
   hardware = {

--- a/doc/_support/devices/generate-devices-listing.rb
+++ b/doc/_support/devices/generate-devices-listing.rb
@@ -92,6 +92,10 @@ $devicesInfo.values.each do |info|
   identifier = info["device"]["identifier"]
   puts ":: Generating devices/#{identifier}.md"
   File.open(File.join($out, "devices/#{identifier}.md"), "w") do |file|
+    links = [
+      ["Product page", info["device"]["productPageURL"]]
+    ].select { |pair| !!pair.last }
+
     file.puts <<~EOF
 
     <section class="device-sidebar">
@@ -113,6 +117,16 @@ $devicesInfo.values.each do |info|
           <dd>#{info["system"]["system"]}</dd>
         <dt>Source</dt>
           <dd><a href="#{githubURL(identifier)}">Tow-Boot repository</a></dd>
+        #{if links.length > 0 then
+          <<~EOL
+          <dt>Links</dt>
+            #{
+            links.map do |pair|
+              %Q{<dd><a href="#{pair.last}">#{pair.first}</a></dd>}
+            end.join("\n")
+            }
+          EOL
+        end}
       </dl>
     </section>
 

--- a/modules/device.nix
+++ b/modules/device.nix
@@ -37,6 +37,15 @@ in
         '';
         type = types.str;
       };
+      productPageURL = mkOption {
+        description = ''
+          URL to the product page.
+
+          Prefer the more "showcase" URL than a store page.
+        '';
+        default = null;
+        type = with types; nullOr str;
+      };
     };
   };
 }

--- a/modules/metadata.nix
+++ b/modules/metadata.nix
@@ -39,6 +39,7 @@ in
               identifier
               name
               manufacturer
+              productPageURL
             ;
             fullName = "${config.device.manufacturer} ${config.device.name}";
           };


### PR DESCRIPTION
This is useful as a starting point for end-users who need to access any vendor provided resource.

This closes #107.

URLs *mostly* directly taken from #107; main difference is for Pine64 systems, where I (1) used the product page instead of the store page and (2) added the new boards just merged.

cc @Strit