### PR TITLE
radxa-RockPi4: Fix identifier for RockPi 4 model A/B

### DIFF
--- a/boards/radxa-RockPi4/default.nix
+++ b/boards/radxa-RockPi4/default.nix
@@ -4,7 +4,7 @@
   device = {
     manufacturer = "Radxa";
     name = lib.mkDefault "ROCK Pi 4 model A/B";
-    identifier = lib.mkDefault "radxa-RockPi4";
+    identifier = lib.mkDefault "radxa-rockPi4";
     productPageURL = "https://wiki.radxa.com/Rockpi4";
   };
 


### PR DESCRIPTION
This closes https://github.com/Tow-Boot/Tow-Boot/issues/122

I'm really confused about this. Will test the release files for the 4C, too (EDIT: 4C works fine).