### PR TITLE
radxa-RockPi4(C): Add SPI documentation

### DIFF
--- a/boards/radxa-RockPi4/README.md
+++ b/boards/radxa-RockPi4/README.md
@@ -1,0 +1,12 @@
+# Radxa ROCK Pi 4 model A/B
+
+## Device-specific notes
+
+According to the [upstream SPI documentation](https://wiki.radxa.com/Rockpi4/hardware/spi_flash),
+the SPI flash is only populated on board revisions V1.4 and later.
+
+While the schematics denote `W25Q64FV` is used, all verified units came
+with an `XT25F32B`.
+
+If no flash is present, the user either needs to use the shared storage strategy,
+or needs to manually solder on some pin-compatible SPI flash (`SOP8` footprint).

--- a/boards/radxa-RockPi4C/README.md
+++ b/boards/radxa-RockPi4C/README.md
@@ -1,0 +1,6 @@
+# Radxa ROCK Pi 4 model C
+
+## Device-specific notes
+
+This board is nearly identical to the [Radxa ROCK Pi 4 A/B](./devices/radxa-RockPi4.html).
+As a result, all device-specific notes from there also apply here.


### PR DESCRIPTION
This PR adds device-specific notes for the RockPi 4 A/B/C about the presence of SPI and what to do if it is not present.

Hope it's fine/correct to target the `released` branch for this type of documentation.