### PR TITLE
doc/getting-started: ask to grow the GPT partition to physical size

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -85,6 +85,15 @@ but the size has been chosen to allow further expansion if needed.
    ```
     # dd if=shared.disk-image.img of=/dev/XXX bs=1M oflag=direct,sync status=progress
    ```
+
+1. Some partitioning tools require the secondary GPT to be at the end of the
+   disk before attempting any operations. Grow the GPT partition to the physical
+   size of the medium. (This operation is a no-op that forces a rewrite of the
+   partition table.)
+   ```
+    # sfdisk --append /dev/XXX
+   ```
+
 1. Boot the media on your board
 
 > **NOTE**: When installing your operating system, make sure that you do not

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -89,8 +89,8 @@ but the size has been chosen to allow further expansion if needed.
 
 > **NOTE**: When installing your operating system, make sure that you do not
 > re-create the partition table from scratch, only edit the existing one.
-> The *Installing an Operating System* section from this manual will remind
-> you.
+> The [*Installing an Operating System*](installing-an-operating-system.md)
+> section from this manual will remind you.
 
 Using the *shared storage* strategy, you can simulate *dedicated storage* by
 **not** installing and using the storage media the platform firmware lives


### PR DESCRIPTION
Otherwise, fdisk and friends first warn about the GPT being possibly
"corrupt", because the backup GPT table is not at the end of the medium.

Fixes https://github.com/Tow-Boot/Tow-Boot/issues/52.