### PR TITLE
odroid-N2: Add support for XT25Q64D

### DIFF
--- a/boards/odroid-N2/0002-Add-support-for-XTX-SPI-XT25Q64D.patch
+++ b/boards/odroid-N2/0002-Add-support-for-XTX-SPI-XT25Q64D.patch
@@ -1,0 +1,35 @@
+From ba58f0f3eadc1755158dec3ea1c063d53c0e702a Mon Sep 17 00:00:00 2001
+From: Ulrik Strid <ulrik.strid@outlook.com>
+Date: Tue, 26 Apr 2022 09:27:57 +0200
+Subject: [PATCH 2/2] Add support for XTX SPI XT25Q64D
+
+Signed-off-by: Ulrik Strid <ulrik.strid@outlook.com>
+---
+ configs/odroid-n2_defconfig   | 1 +
+ drivers/mtd/spi/spi-nor-ids.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/configs/odroid-n2_defconfig b/configs/odroid-n2_defconfig
+index b19f98585c..3dbcba703b 100644
+--- a/configs/odroid-n2_defconfig
++++ b/configs/odroid-n2_defconfig
+@@ -76,3 +76,4 @@ CONFIG_BMP_16BPP=y
+ CONFIG_SPI=y
+ CONFIG_DM_SPI=y
+ CONFIG_MESON_SPIFC=y
++CONFIG_SPI_FLASH_XTX=y
+diff --git a/drivers/mtd/spi/spi-nor-ids.c b/drivers/mtd/spi/spi-nor-ids.c
+index 763bab04c6..67a3406cb1 100644
+--- a/drivers/mtd/spi/spi-nor-ids.c
++++ b/drivers/mtd/spi/spi-nor-ids.c
+@@ -381,6 +381,7 @@ const struct flash_info spi_nor_ids[] = {
+ #ifdef CONFIG_SPI_FLASH_XTX
+ 	/* XTX Technology (Shenzhen) Limited */
+ 	{ INFO("xt25f128b", 0x0b4018, 0, 64 * 1024, 256, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++	{ INFO("XT25Q64D", 0x0b6017, 0, 64 * 1024, 128, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ #endif
+ 	{ },
+ };
+-- 
+2.35.1
+

--- a/boards/odroid-N2/default.nix
+++ b/boards/odroid-N2/default.nix
@@ -25,6 +25,7 @@
     patches = [
       # ODROID N2 SPI support
       ./0001-Enable-the-SPI-on-the-ODROID-N2-by-default.patch
+      ./0002-Add-support-for-XTX-SPI-XT25Q64D.patch
     ];
     builder.additionalArguments = {
       FIPDIR = "${pkgs.Tow-Boot.amlogicFirmware}/odroid-n2";


### PR DESCRIPTION
This adds a build for the odroid N2+ computer. Also adds support for the XTX SPI XT25Q64D