### PR TITLE
pine64-rock64: Add support for ROCK64

### DIFF
--- a/boards/pine64-rock64/0001-ayufan-usb-enablement.patch
+++ b/boards/pine64-rock64/0001-ayufan-usb-enablement.patch
@@ -1,0 +1,135 @@
+From 878b3ea50f6f0a1b8f705187dbc4f395c9c687bd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kamil=20Trzci=C5=84ski?= <ayufan@ayufan.eu>
+Date: Mon, 6 Apr 2020 11:36:42 +0200
+Subject: [PATCH 1/3] ayufan: dwc3: of-simple: add `rockchip,rk3328-dwc3`
+
+---
+ drivers/usb/host/dwc3-of-simple.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/usb/host/dwc3-of-simple.c b/drivers/usb/host/dwc3-of-simple.c
+index 66b3e96b007..6c4b5ef18d3 100644
+--- a/drivers/usb/host/dwc3-of-simple.c
++++ b/drivers/usb/host/dwc3-of-simple.c
+@@ -91,6 +91,7 @@ static int dwc3_of_simple_remove(struct udevice *dev)
+ 
+ static const struct udevice_id dwc3_of_simple_ids[] = {
+ 	{ .compatible = "amlogic,meson-gxl-dwc3" },
++	{ .compatible = "rockchip,rk3328-dwc3" },
+ 	{ .compatible = "rockchip,rk3399-dwc3" },
+ 	{ .compatible = "ti,dwc3" },
+ 	{ }
+-- 
+2.35.1
+
+
+From 2b59c201b0e75d98a61776f340be5296d8bc47d9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kamil=20Trzci=C5=84ski?= <ayufan@ayufan.eu>
+Date: Mon, 6 Apr 2020 12:52:29 +0200
+Subject: [PATCH 2/3] ayufan: dts: rock64: configure vbus-supply on USB
+
+---
+ arch/arm/dts/rk3328-rock64-u-boot.dtsi | 1 +
+ arch/arm/dts/rk3328-rock64.dts         | 4 ++--
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm/dts/rk3328-rock64-u-boot.dtsi b/arch/arm/dts/rk3328-rock64-u-boot.dtsi
+index fe906e76a48..be1078ce16d 100644
+--- a/arch/arm/dts/rk3328-rock64-u-boot.dtsi
++++ b/arch/arm/dts/rk3328-rock64-u-boot.dtsi
+@@ -55,6 +55,7 @@
+ &usb_host0_xhci {
+ 	vbus-supply = <&vcc_host_5v>;
+ 	status = "okay";
++	dr_mode = "host";
+ };
+ 
+ /*
+diff --git a/arch/arm/dts/rk3328-rock64.dts b/arch/arm/dts/rk3328-rock64.dts
+index f69a38f42d2..d04eb76dd63 100644
+--- a/arch/arm/dts/rk3328-rock64.dts
++++ b/arch/arm/dts/rk3328-rock64.dts
+@@ -43,8 +43,6 @@
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&usb20_host_drv>;
+ 		regulator-name = "vcc_host_5v";
+-		regulator-always-on;
+-		regulator-boot-on;
+ 		vin-supply = <&vcc_sys>;
+ 	};
+ 
+@@ -388,10 +386,12 @@
+ 
+ &usb_host0_ehci {
+ 	status = "okay";
++	vbus-supply = <&vcc_host_5v>;
+ };
+ 
+ &usb_host0_ohci {
+ 	status = "okay";
++	vbus-supply = <&vcc_host_5v>;
+ };
+ 
+ &vop {
+-- 
+2.35.1
+
+
+From 277dbac282011e149fbb83b3b6a78fa0482f4507 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Fri, 17 Jun 2022 17:28:21 -0400
+Subject: [PATCH 3/3] dts: rock64: apply configuration only to U-Boot FDT
+
+---
+ arch/arm/dts/rk3328-rock64-u-boot.dtsi | 8 ++++++++
+ arch/arm/dts/rk3328-rock64.dts         | 4 ++--
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm/dts/rk3328-rock64-u-boot.dtsi b/arch/arm/dts/rk3328-rock64-u-boot.dtsi
+index be1078ce16d..9f4c7ca4a93 100644
+--- a/arch/arm/dts/rk3328-rock64-u-boot.dtsi
++++ b/arch/arm/dts/rk3328-rock64-u-boot.dtsi
+@@ -68,6 +68,14 @@
+ 	/delete-property/ regulator-boot-on;
+ };
+ 
++&usb_host0_ehci {
++	vbus-supply = <&vcc_host_5v>;
++};
++
++&usb_host0_ohci {
++	vbus-supply = <&vcc_host_5v>;
++};
++
+ /* Need this and all the pinctrl/gpio stuff above to set pinmux */
+ &vcc_sd {
+ 	u-boot,dm-spl;
+diff --git a/arch/arm/dts/rk3328-rock64.dts b/arch/arm/dts/rk3328-rock64.dts
+index d04eb76dd63..f69a38f42d2 100644
+--- a/arch/arm/dts/rk3328-rock64.dts
++++ b/arch/arm/dts/rk3328-rock64.dts
+@@ -43,6 +43,8 @@
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&usb20_host_drv>;
+ 		regulator-name = "vcc_host_5v";
++		regulator-always-on;
++		regulator-boot-on;
+ 		vin-supply = <&vcc_sys>;
+ 	};
+ 
+@@ -386,12 +388,10 @@
+ 
+ &usb_host0_ehci {
+ 	status = "okay";
+-	vbus-supply = <&vcc_host_5v>;
+ };
+ 
+ &usb_host0_ohci {
+ 	status = "okay";
+-	vbus-supply = <&vcc_host_5v>;
+ };
+ 
+ &vop {
+-- 
+2.35.1
+

--- a/boards/pine64-rock64/0001-board-rock64-Enable-booting-from-SPI-flash.patch
+++ b/boards/pine64-rock64/0001-board-rock64-Enable-booting-from-SPI-flash.patch
@@ -1,0 +1,69 @@
+From 585149b7b2dbfd957afce9c4f455319558a6321f Mon Sep 17 00:00:00 2001
+From: Andrew Abbott <andrew@mirx.dev>
+Date: Sat, 27 Nov 2021 20:38:43 +1100
+Subject: [PATCH] board: rock64: Enable booting from SPI flash
+
+For some reason, the RK3328 uses rksd-format images when loading from
+SPI.
+
+CONFIG_SYS_SPI_U_BOOT_OFFS has been set the same as the ROCKPro64, since
+the boards have the same size flash and thus can share the same layout.
+
+Origin: https://github.com/mirrexagon/u-boot/commit/239a2984da3290a0b59ba623cb1294b77ef334a5
+
+Modified to apply on stock U-Boot, without the other changes from the
+originating branch.
+---
+ arch/arm/dts/rk3328-rock64-u-boot.dtsi | 2 +-
+ arch/arm/mach-rockchip/rk3328/rk3328.c | 1 +
+ configs/rock64-rk3328_defconfig        | 5 +++++
+ 3 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/dts/rk3328-rock64-u-boot.dtsi b/arch/arm/dts/rk3328-rock64-u-boot.dtsi
+index 3c3b1370e31..32155a516d3 100644
+--- a/arch/arm/dts/rk3328-rock64-u-boot.dtsi
++++ b/arch/arm/dts/rk3328-rock64-u-boot.dtsi
+@@ -7,7 +7,7 @@
+ #include "rk3328-sdram-lpddr3-1600.dtsi"
+ / {
+ 	chosen {
+-		u-boot,spl-boot-order = "same-as-spl", &sdmmc, &emmc;
++		u-boot,spl-boot-order = "same-as-spl", &spi_flash, &sdmmc, &emmc;
+ 	};
+ 
+ 	smbios {
+diff --git a/arch/arm/mach-rockchip/rk3328/rk3328.c b/arch/arm/mach-rockchip/rk3328/rk3328.c
+index ec3336cb49a..160212cbd25 100644
+--- a/arch/arm/mach-rockchip/rk3328/rk3328.c
++++ b/arch/arm/mach-rockchip/rk3328/rk3328.c
+@@ -22,6 +22,7 @@ DECLARE_GLOBAL_DATA_PTR;
+ 
+ const char * const boot_devices[BROM_LAST_BOOTSOURCE + 1] = {
+ 	[BROM_BOOTSOURCE_EMMC] = "/rksdmmc@ff520000",
++	[BROM_BOOTSOURCE_SPINOR] = "/spi@ff190000/spiflash@0",
+ 	[BROM_BOOTSOURCE_SD] = "/rksdmmc@ff500000",
+ };
+ 
+diff --git a/configs/rock64-rk3328_defconfig b/configs/rock64-rk3328_defconfig
+index f0ef1e5c98f..29d9c0119c1 100644
+--- a/configs/rock64-rk3328_defconfig
++++ b/configs/rock64-rk3328_defconfig
+@@ -14,6 +14,10 @@ CONFIG_SPL_STACK_R_ADDR=0x600000
+ CONFIG_DEBUG_UART_BASE=0xFF130000
+ CONFIG_DEBUG_UART_CLOCK=24000000
+ CONFIG_DEBUG_UART=y
++CONFIG_SPL_SPI_FLASH_SUPPORT=y
++CONFIG_SPL_SPI=y
++CONFIG_SYS_SPI_U_BOOT_OFFS=0x60000
++CONFIG_SPL_SPI_LOAD=y
+ CONFIG_TPL_SYS_MALLOC_F_LEN=0x800
+ # CONFIG_ANDROID_BOOT_IMAGE is not set
+ CONFIG_FIT=y
+@@ -100,3 +104,4 @@ CONFIG_USB_GADGET_DWC2_OTG=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_TPL_TINY_MEMSET=y
+ CONFIG_ERRNO_STR=y
++CONFIG_ROCKCHIP_SPI_IMAGE=y
+-- 
+2.35.1
+

--- a/boards/pine64-rock64/README.md
+++ b/boards/pine64-rock64/README.md
@@ -1,0 +1,20 @@
+# PINE64 ROCK64
+
+## Device-specific notes
+
+There is no display output for this device.
+
+The vendor no longer includes SPI Flash chip on recent units.
+
+## Recovering from a bad SPI flash
+
+The SPI Flash can be “tied-down” (disabled) and removed from the startup order
+by connecting **pin 23** (`SPI_SCLK`) to **ground** (e.g. pin 25 or 39) on the
+*Pi2-compatible* connector.
+
+Refer to the upstream schematic for the pin descriptions:
+
+ - http://files.pine64.org/doc/Pine%20A64%20Schematic/Pine%20A64%20Pin%20Assignment%20160119.pdf
+
+You can install or erase the content of the SPI Flash by disconnecting the pins
+once a proper Tow-Boot build is started.

--- a/boards/pine64-rock64/default.nix
+++ b/boards/pine64-rock64/default.nix
@@ -1,0 +1,21 @@
+{
+  device = {
+    manufacturer = "PINE64";
+    name = "ROCK64";
+    identifier = "pine64-rock64";
+    productPageURL = "https://www.pine64.org/rock64/";
+  };
+
+  hardware = {
+    soc = "rockchip-rk3328";
+    SPISize = 16 * 1024 * 1024; # 16 MiB
+    withDisplay = false;
+  };
+
+  Tow-Boot = {
+    defconfig = "rock64-rk3328_defconfig";
+    patches = [
+      ./0001-board-rock64-Enable-booting-from-SPI-flash.patch
+    ];
+  };
+}

--- a/boards/pine64-rock64/default.nix
+++ b/boards/pine64-rock64/default.nix
@@ -16,6 +16,7 @@
     defconfig = "rock64-rk3328_defconfig";
     patches = [
       ./0001-board-rock64-Enable-booting-from-SPI-flash.patch
+      ./0001-ayufan-usb-enablement.patch
     ];
   };
 }

--- a/modules/hardware/default.nix
+++ b/modules/hardware/default.nix
@@ -59,6 +59,13 @@ in
           internal = true;
         };
       };
+      withDisplay = mkOption{
+        type = types.bool;
+        default = true;
+        description = ''
+          When true, the build is made assuming the display drivers are available and work.
+        '';
+      };
     };
   };
   config = mkMerge [

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -56,6 +56,9 @@ in
             SPL_DM_SPI = yes;
             SPL_SPI_FLASH_TINY = no;
             SPL_SPI_FLASH_SFDP_SUPPORT = yes;
+            SPL_SPI_SUPPORT = yes;
+            SPL_SPI_FLASH_SUPPORT = yes;
+            SPL_SPI_LOAD = yes;
             SYS_SPI_U_BOOT_OFFS = freeform ''0x80000''; # 512K
             SPL_DM_SEQ_ALIAS = yes;
           }))

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -30,6 +30,7 @@ let
   anyRockchip = lib.any (soc: config.hardware.socs.${soc}.enable) rockchipSOCs;
   isPhoneUX = config.Tow-Boot.phone-ux.enable;
   withSPI = config.hardware.SPISize != null;
+  useSpi2K4Kworkaround = cfg.rockchip-rk3399.enable;
   chipName =
          if cfg.rockchip-rk3328.enable then "rk3328"
     else if cfg.rockchip-rk3399.enable then "rk3399"
@@ -129,8 +130,8 @@ in
             ;
           };
           installPhase = mkMerge [
-            (mkIf (variant == "spi") ''
-              echo ":: Preparing image for SPI flash..."
+            (mkIf (variant == "spi" && useSpi2K4Kworkaround) ''
+              echo ":: Preparing image for SPI flash (2K/4K workaround)..."
               (PS4=" $ "; set -x
               tools/mkimage \
                 -n ${chipName} \

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -30,6 +30,11 @@ let
   anyRockchip = lib.any (soc: config.hardware.socs.${soc}.enable) rockchipSOCs;
   isPhoneUX = config.Tow-Boot.phone-ux.enable;
   withSPI = config.hardware.SPISize != null;
+  chipName =
+         if cfg.rockchip-rk3328.enable then "rk3328"
+    else if cfg.rockchip-rk3399.enable then "rk3399"
+    else throw "chipName needs to be defined for SoC."
+  ;
 in
 {
   options = {
@@ -127,7 +132,10 @@ in
             (mkIf (variant == "spi") ''
               echo ":: Preparing image for SPI flash..."
               (PS4=" $ "; set -x
-              tools/mkimage -n rk3399 -T rkspi -d tpl/u-boot-tpl-dtb.bin:spl/u-boot-spl-dtb.bin spl.bin
+              tools/mkimage \
+                -n ${chipName} \
+                -T "rkspi" \
+                -d "tpl/u-boot-tpl-dtb.bin:spl/u-boot-spl-dtb.bin" spl.bin
               # 512K here is 0x80000 CONFIG_SYS_SPI_U_BOOT_OFFS
               cat <(dd if=spl.bin bs=512K conv=sync) u-boot.itb > $out/binaries/Tow-Boot.$variant.bin
               )

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -24,6 +24,7 @@ let
 
   anyRockchip = lib.any (v: v) [cfg.rockchip-rk3399.enable];
   isPhoneUX = config.Tow-Boot.phone-ux.enable;
+  withSPI = config.hardware.SPISize != null;
 in
 {
   options = {
@@ -47,7 +48,7 @@ in
       system.system = "aarch64-linux";
       Tow-Boot = {
         config = [
-          (helpers: with helpers; {
+          (mkIf withSPI (helpers: with helpers; {
             # SPI boot Support
             MTD = yes;
             DM_MTD = yes;
@@ -57,7 +58,9 @@ in
             SPL_SPI_FLASH_SFDP_SUPPORT = yes;
             SYS_SPI_U_BOOT_OFFS = freeform ''0x80000''; # 512K
             SPL_DM_SEQ_ALIAS = yes;
+          }))
 
+          (helpers: with helpers; {
             # Not supported on this platform
             CMD_POWEROFF = no;
           })

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -22,13 +22,25 @@ let
   secondOffset = 16384; # in sectors
   sectorSize = 512;
 
-  anyRockchip = lib.any (v: v) [cfg.rockchip-rk3399.enable];
+  rockchipSOCs = [
+    "rockchip-rk3328"
+    "rockchip-rk3399"
+  ];
+
+  anyRockchip = lib.any (soc: config.hardware.socs.${soc}.enable) rockchipSOCs;
   isPhoneUX = config.Tow-Boot.phone-ux.enable;
   withSPI = config.hardware.SPISize != null;
 in
 {
   options = {
     hardware.socs = {
+      rockchip-rk3328.enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable when SoC is Rockchip RK3328";
+        internal = true;
+      };
+
       rockchip-rk3399.enable = mkOption {
         type = types.bool;
         default = false;
@@ -40,11 +52,9 @@ in
 
   config = mkMerge [
     {
-      hardware.socList = [
-        "rockchip-rk3399"
-      ];
+      hardware.socList = rockchipSOCs;
     }
-    (mkIf cfg.rockchip-rk3399.enable {
+    (mkIf anyRockchip {
       system.system = "aarch64-linux";
       Tow-Boot = {
         config = [
@@ -100,13 +110,12 @@ in
           ])
         ];
         firmwarePartition = {
-            offset = partitionOffset * 512; # 32KiB into the image, or 64 × 512 long sectors
+            offset = partitionOffset * sectorSize; # 32KiB into the image, or 64 × 512 long sectors
             length = firmwareMaxSize + (secondOffset * sectorSize); # in bytes
           }
         ;
         builder = {
           additionalArguments = {
-            BL31 = "${pkgs.Tow-Boot.armTrustedFirmwareRK3399}/bl31.elf";
             inherit
               firmwareMaxSize
               partitionOffset
@@ -134,6 +143,14 @@ in
           ];
         };
       };
+    })
+
+    (mkIf cfg.rockchip-rk3328.enable {
+      Tow-Boot.builder.additionalArguments.BL31 = "${pkgs.Tow-Boot.armTrustedFirmwareRK3328}/bl31.elf";
+    })
+
+    (mkIf cfg.rockchip-rk3399.enable {
+      Tow-Boot.builder.additionalArguments.BL31 = "${pkgs.Tow-Boot.armTrustedFirmwareRK3399}/bl31.elf";
     })
 
     # Documentation fragments

--- a/modules/tow-boot/options.nix
+++ b/modules/tow-boot/options.nix
@@ -78,7 +78,7 @@ in
 
       withLogo = mkOption {
         type = types.bool;
-        default = true;
+        default = config.hardware.withDisplay;
         description = ''
           Build with support for the logo.
 

--- a/support/overlay/overlay.nix
+++ b/support/overlay/overlay.nix
@@ -54,6 +54,7 @@ in
 
     inherit (callPackage ./arm-trusted-firmware { })
       armTrustedFirmwareAllwinner
+      armTrustedFirmwareRK3328
       armTrustedFirmwareRK3399
       armTrustedFirmwareS905
     ;


### PR DESCRIPTION
As mainline U-Boot contains support for the ROCK64, I added support for it to Tow-Boot. 

Fixes #151 