### PR TITLE
Add smbios for all

### DIFF
--- a/modules/tow-boot/default.nix
+++ b/modules/tow-boot/default.nix
@@ -7,6 +7,7 @@
     ./installer.nix
     ./options.nix
     ./phone-ux.nix
+    ./smbios.nix
     ./src.nix
   ];
 }

--- a/modules/tow-boot/smbios.nix
+++ b/modules/tow-boot/smbios.nix
@@ -1,5 +1,39 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
+let
+  inherit (pkgs)
+    writeText
+  ;
+
+  # Close enough semantics to C semantics and thus DT strings.
+  escape = builtins.toJSON;
+
+  # Fallback values used if the device description has none.
+  smbios_dtsi = writeText "${config.device.identifier}-smbios.dtsi" ''
+    / {
+      smbios: smbios {
+          compatible = "u-boot,sysinfo-smbios";
+
+          smbios {
+              system {
+                  manufacturer = ${escape config.device.manufacturer};
+                  product = ${escape config.device.name};
+              };
+
+              baseboard {
+                  manufacturer = ${escape config.device.manufacturer};
+                  product = ${escape config.device.name};
+              };
+
+              chassis {
+                  manufacturer = ${escape config.device.manufacturer};
+                  product = ${escape config.device.name};
+              };
+          };
+      };
+    };
+  '';
+in
 {
   Tow-Boot = {
     config = [
@@ -9,5 +43,27 @@
         SYSINFO_SMBIOS = yes;
       })
     ];
+    builder = {
+      # This forcibly adds fallback values for SMBIOS support in device tree files.
+      # This will ensure no "unknown vendor" and such are present, but will instead
+      # force a board-specific value in sysinfo.
+      #
+      # Boards should still add the appropriate DT entries to their `u-boot.dtsi` files.
+      # Especially if the build is shared across different hardware
+      # like for the Pinephone (A64) and Raspberry Pi.
+      #
+      # The fallback values are added only to the "tip-most" *u-boot.dtsi files.
+      postPatch = ''
+        echo " :: Adding build-specific defaults for SMBIOS support..."
+        for f in $(grep -L '#include.*u-boot.dtsi' arch/arm/dts/*u-boot.dtsi); do
+          (
+            echo '#include "smbios.dtsi"'
+            cat "$f"
+          ) > tmp.dts
+          mv tmp.dts "$f"
+        done
+        cp ${smbios_dtsi} arch/arm/dts/smbios.dtsi
+      '';
+    };
   };
 }

--- a/modules/tow-boot/smbios.nix
+++ b/modules/tow-boot/smbios.nix
@@ -1,0 +1,13 @@
+{ config, lib, ... }:
+
+{
+  Tow-Boot = {
+    config = [
+      (helpers: with helpers; {
+        # Used to provide SMBIOS information, mainly for UEFI boot.
+        SYSINFO = yes;
+        SYSINFO_SMBIOS = yes;
+      })
+    ];
+  };
+}


### PR DESCRIPTION
This is a follow-up to #135, and **does not** obsolete #135.

* * *

This change set provides an automatic fallback for smbios data that will come from the intrinsic knowledge Tow-Boot already has about the platform.

This is a *fallback* value, as it is defined in the "earliest" available `*-u-boot.dtsi` file, which means that when upstream U-Boot implements the appropriate data in their device trees, the values will be the ones from upstream *as it should be*.

This also means we should make it an habit, and part of the "port" process to contribute the smbios data for the devices to upstream.

* * *

Tested on:

 - [x] Allwinner [Pinebook (A64)]
 - [x] Rockchip [Pinebook Pro]
 - [x] Amlogic [radxa-zero2]
 - [x] Raspberry Pi
     - [x] 3
     - [x] 4
 - [x] Pinephone Pro + #135.

* * *

### Notes

On Raspberry Pi 3, the SMBIOS information is not great. This is because the way this is implemented *indeed* only works as a fallback. [The generic data defined for all Raspberry Pi platforms is used instead](https://source.denx.de/u-boot/u-boot/-/blob/90189ecd59cdf14afbe6014be5c068e599b65a72/arch/arm/dts/bcm283x-u-boot.dtsi#L10-25). This was expected.

On Raspberry Pi 4, I think what is happening is that there is no built-in information in U-Boot to use the fallback information. So at the current time it's showing *Unknown* and *Unknown Product*.

Given the general difficulties with the Raspberry Pi platforms, this is okay. Anyway packaging for Raspberry Pi is planned to be revised, so putting a lot of effort into something that will most likely change is not ideal.

On all other tested platforms the fallback values were used as expected.