### PR TITLE
Add support for the ODROID-C4

### DIFF
--- a/boards/odroid-C4/README.md
+++ b/boards/odroid-C4/README.md
@@ -1,0 +1,7 @@
+# ODROID-C4
+
+## Device-specific notes
+
+Due to device tree issues, using UEFI boot (i.e. booting an ISO off USB) is not
+currently useful as the boot media may not be detected, and internal storage
+(SD or eMMC) will definitely not be detected.

--- a/boards/odroid-C4/default.nix
+++ b/boards/odroid-C4/default.nix
@@ -1,0 +1,27 @@
+{ lib, pkgs, ... }:
+
+{
+  device = {
+    manufacturer = "ODROID";
+    name = "C4";
+    identifier = "odroid-C4";
+    productPageURL = "https://www.hardkernel.com/shop/odroid-c4/";
+  };
+
+  hardware = {
+    soc = "amlogic-s905x3";
+  };
+
+  Tow-Boot = {
+    defconfig = "odroid-c4_defconfig";
+    config = [
+      (helpers: with helpers; {
+        USE_PREBOOT = yes;
+        PREBOOT = freeform ''"usb start ; usb info"'';
+      })
+    ];
+    builder.additionalArguments = {
+      FIPDIR = "${pkgs.Tow-Boot.amlogicFirmware}/odroid-c4";
+    };
+  };
+}

--- a/modules/hardware/amlogic/default.nix
+++ b/modules/hardware/amlogic/default.nix
@@ -18,6 +18,7 @@ let
   amlogicG12 = lib.any (soc: config.hardware.socs.${soc}.enable) [
     "amlogic-a311d"
     "amlogic-s922x"
+    "amlogic-s905x3" # technically an SM1 family member, but the boot process is identical to G12
   ];
   amlogicGXL = lib.any (soc: config.hardware.socs.${soc}.enable) [
     "amlogic-s805x"
@@ -54,6 +55,12 @@ in
         description = "Enable when SoC is Amlogic S905";
         internal = true;
       };
+      amlogic-s905x3.enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable when SoC is Amlogic S905X3";
+        internal = true;
+      };
       amlogic-s922x.enable = mkOption {
         type = types.bool;
         default = false;
@@ -69,6 +76,7 @@ in
         "amlogic-a311d"
         "amlogic-s805x"
         "amlogic-s905"
+        "amlogic-s905x3"
         "amlogic-s922x"
       ];
     }
@@ -79,6 +87,9 @@ in
       system.system = "aarch64-linux";
     })
     (mkIf cfg.amlogic-s905.enable {
+      system.system = "aarch64-linux";
+    })
+    (mkIf cfg.amlogic-s905x3.enable {
       system.system = "aarch64-linux";
     })
     (mkIf cfg.amlogic-s922x.enable {


### PR DESCRIPTION
Verified that the following functionality works:
* HDMI output and USB keyboard input
* Serial console input and output using ODROID's official dongle and connector
* Extlinux boot off SD, eMMC, and USB devices of official NixOS 22.05 kernel 5.15 SD images
* DHCP obtainment of IP address

Unfortunately UEFI boot does not work properly, likely due to U-Boot shipping an incompatible device tree.

I tested installing NixOS by adding a root partition using `fdisk` and making it bootable, then `dd`ing the root partition from the official SD image (not the whole image) over to my new partition. I also tested that it's possible to `dd` the whole SD image to a flash drive and boot it, but that's kind of silly.

I'm not sure if the Amlogic S905X3 is deserving of its own SM1 family group as the boot logic and preparation is evidently compatible with the G12 family. For now I decided to just place it with the G12 logic.

This work should also be compatible with the ODROID-HC4 through little more than adding an `h` to the board and device tree name. But I don't have one to test with.