### PR TITLE
bananaPi-p2Maker: Add support for Banana Pi P2 Maker

### DIFF
--- a/boards/bananaPi-p2Maker/0001-sunxi-add-Banana-Pi-P2-Maker.patch
+++ b/boards/bananaPi-p2Maker/0001-sunxi-add-Banana-Pi-P2-Maker.patch
@@ -1,0 +1,359 @@
+From 68d732469510d989e12079069665ba247bf3f7c4 Mon Sep 17 00:00:00 2001
+From: leo60228 <leo@60228.dev>
+Date: Fri, 15 Jul 2022 15:25:17 -0400
+Subject: [PATCH] sunxi: add Banana Pi P2 Maker
+
+The Banana Pi P2 Maker is closely related to the already supported Banana
+Pi M2 Zero, but adds Ethernet with optional PoE.
+---
+ arch/arm/dts/Makefile                         |   1 +
+ .../dts/sun8i-h2-plus-bananapi-p2-maker.dts   | 281 ++++++++++++++++++
+ arch/arm/dts/sunxi-h3-h5.dtsi                 |   4 +
+ configs/bananapi_p2_maker_defconfig           |  13 +
+ 4 files changed, 299 insertions(+)
+ create mode 100644 arch/arm/dts/sun8i-h2-plus-bananapi-p2-maker.dts
+ create mode 100644 configs/bananapi_p2_maker_defconfig
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 66c719908c..b28e31c3fe 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -645,6 +645,7 @@ dtb-$(CONFIG_MACH_SUN8I_A83T) += \
+ 	sun8i-a83t-tbs-a711.dtb
+ dtb-$(CONFIG_MACH_SUN8I_H3) += \
+ 	sun8i-h2-plus-bananapi-m2-zero.dtb \
++	sun8i-h2-plus-bananapi-p2-maker.dtb \
+ 	sun8i-h2-plus-libretech-all-h3-cc.dtb \
+ 	sun8i-h2-plus-orangepi-r1.dtb \
+ 	sun8i-h2-plus-orangepi-zero.dtb \
+diff --git a/arch/arm/dts/sun8i-h2-plus-bananapi-p2-maker.dts b/arch/arm/dts/sun8i-h2-plus-bananapi-p2-maker.dts
+new file mode 100644
+index 0000000000..94cff79978
+--- /dev/null
++++ b/arch/arm/dts/sun8i-h2-plus-bananapi-p2-maker.dts
+@@ -0,0 +1,281 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (C) 2022 leo60228 <leo@60228.dev>
++ *
++ * Based on sun8i-h2-plus-bananapi-m2-zero.dts, which is:
++ *   Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
++ */
++
++/dts-v1/;
++#include "sun8i-h3.dtsi"
++#include "sunxi-common-regulators.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++
++/ {
++	model = "Banana Pi BPI-P2-Maker";
++	compatible = "sinovoip,bpi-p2-maker", "allwinner,sun8i-h2-plus";
++
++	aliases {
++		ethernet0 = &emac;
++		serial0 = &uart0;
++		serial1 = &uart1;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	connector {
++		compatible = "hdmi-connector";
++		type = "c";
++
++		port {
++			hdmi_con_in: endpoint {
++				remote-endpoint = <&hdmi_out_con>;
++			};
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		pwr_led {
++			label = "bananapi-p2-maker:red:pwr";
++			gpios = <&r_pio 0 10 GPIO_ACTIVE_LOW>; /* PL10 */
++			default-state = "on";
++		};
++	};
++
++	gpio_keys {
++		compatible = "gpio-keys";
++
++		sw4 {
++			label = "power";
++			linux,code = <KEY_POWER>;
++			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>;
++			wakeup-source;
++		};
++	};
++
++	reg_vdd_cpux: vdd-cpux-regulator {
++		compatible = "regulator-gpio";
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>; /* 4ms */
++
++		gpios = <&r_pio 0 1 GPIO_ACTIVE_HIGH>; /* PL1 */
++		enable-active-high;
++		gpios-states = <0x1>;
++		states = <1100000 0>, <1300000 1>;
++	};
++
++	reg_vcc_dram: vcc-dram {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-dram";
++		regulator-min-microvolt = <1500000>;
++		regulator-max-microvolt = <1500000>;
++		regulator-always-on;
++		regulator-boot-on;
++		enable-active-high;
++		gpio = <&r_pio 0 9 GPIO_ACTIVE_HIGH>; /* PL9 */
++		vin-supply = <&reg_vcc5v0>;
++	};
++
++	reg_vcc1v2: vcc1v2 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc1v2";
++		regulator-min-microvolt = <1200000>;
++		regulator-max-microvolt = <1200000>;
++		regulator-always-on;
++		regulator-boot-on;
++		enable-active-high;
++		gpio = <&r_pio 0 8 GPIO_ACTIVE_HIGH>; /* PL8 */
++		vin-supply = <&reg_vcc5v0>;
++	};
++
++	poweroff {
++		compatible = "regulator-poweroff";
++		cpu-supply = <&reg_vcc1v2>;
++	};
++
++	wifi_pwrseq: wifi_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>; /* PL7 */
++		clocks = <&rtc 1>;
++		clock-names = "ext_clock";
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&reg_vdd_cpux>;
++};
++
++&de {
++	status = "okay";
++};
++
++&ehci0 {
++	status = "okay";
++};
++
++&emac {
++	phy-handle = <&int_mii_phy>;
++	phy-mode = "mii";
++	allwinner,leds-active-low;
++	status = "okay";
++};
++
++&hdmi {
++	status = "okay";
++};
++
++&hdmi_out {
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
++&mmc0 {
++	vmmc-supply = <&reg_vcc3v3>;
++	bus-width = <4>;
++	/*
++	 * On the production batch of this board the card detect GPIO is
++	 * high active (card inserted), although on the early samples it's
++	 * low active.
++	 */
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_HIGH>; /* PF6 */
++	status = "okay";
++};
++
++&mmc1 {
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc3v3>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++
++	brcmf: wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++		interrupt-parent = <&pio>;
++		interrupts = <6 10 IRQ_TYPE_LEVEL_LOW>; /* PG10 / EINT10 */
++		interrupt-names = "host-wake";
++	};
++};
++
++&ohci0 {
++	status = "okay";
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_pa_pins>;
++	status = "okay";
++};
++
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
++	uart-has-rtscts;
++	status = "okay";
++
++	bluetooth {
++		compatible = "brcm,bcm43438-bt";
++		max-speed = <1500000>;
++		clocks = <&rtc 1>;
++		clock-names = "lpo";
++		vbat-supply = <&reg_vcc3v3>;
++		vddio-supply = <&reg_vcc3v3>;
++		device-wakeup-gpios = <&pio 6 13 GPIO_ACTIVE_HIGH>; /* PG13 */
++		host-wakeup-gpios = <&pio 6 11 GPIO_ACTIVE_HIGH>; /* PG11 */
++		shutdown-gpios = <&pio 6 12 GPIO_ACTIVE_HIGH>; /* PG12 */
++	};
++
++};
++
++&pio {
++	gpio-line-names =
++		/* PA */
++		"CON2-P13", "CON2-P11", "CON2-P22", "CON2-P15",
++			"CON3-P03", "CON3-P02", "CON2-P07", "CON2-P29",
++		"CON2-P31", "CON2-P33", "CON2-P35", "CON2-P05",
++			"CON2-P03", "CON2-P08", "CON2-P10", "CON2-P16",
++		"CON2-P12", "CON2-P37", "CON2-P28", "CON2-P27",
++			"CON2-P40", "CON2-P38", "", "",
++		"", "", "", "", "", "", "", "",
++
++		/* PB */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++
++		/* PC */
++		"CON2-P19", "CON2-P21", "CON2-P23", "CON2-P24",
++			"CON2-P18", "", "", "CON2-P26",
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++
++		/* PD */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "CSI-PWR-EN", "",
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++
++		/* PE */
++		"CN3-P17", "CN3-P13", "CN3-P09", "CN3-P07",
++			"CN3-P19", "CN3-P21", "CN3-P22", "CN3-P20",
++		"CN3-P18", "CN3-P16", "CN3-P14", "CN3-P12",
++			"CN3-P05", "CN3-P03", "CN3-P06", "CN3-P08",
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++
++		/* PF */
++		"SDC0-D1", "SDC0-D0", "SDC0-CLK", "SDC0-CMD", "SDC0-D3",
++			"SDC0-D2", "SDC0-DET", "",
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++
++		/* PG */
++		"WL-SDIO-CLK", "WL-SDIO-CMD", "WL-SDIO-D0", "WL-SDIO-D1",
++			"WL-SDIO-D2", "WL-SDIO-D3", "BT-UART-TX", "BT-UART-RX",
++		"BT-UART-RTS", "BT-UART-CTS", "WL-WAKE-AP", "BT-WAKE-AP",
++			"BT-RST-N", "AP-WAKE-BT", "", "",
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "";
++};
++
++&r_pio {
++	gpio-line-names =
++		/* PL */
++		"", "CPUX-SET", "CON2-P32", "POWER-KEY", "CON2-P36",
++			"VCC-IO-EN", "USB0-ID", "WL-PWR-EN",
++		"PWR-STB", "PWR-DRAM", "PWR-LED", "IR-RX", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "";
++};
++
++&usb_otg {
++	dr_mode = "otg";
++	status = "okay";
++};
++
++&usbphy {
++	usb0_id_det-gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>; /* PL6 */
++	/*
++	 * There're two micro-USB connectors, one is power-only and another is
++	 * OTG. The Vbus of these two connectors are connected together, so
++	 * the external USB device will be powered just by the power input
++	 * from the power-only USB port.
++	 */
++	status = "okay";
++};
+diff --git a/arch/arm/dts/sunxi-h3-h5.dtsi b/arch/arm/dts/sunxi-h3-h5.dtsi
+index 6cea57e07f..ade3cc2e71 100644
+--- a/arch/arm/dts/sunxi-h3-h5.dtsi
++++ b/arch/arm/dts/sunxi-h3-h5.dtsi
+@@ -301,6 +301,8 @@
+ 			interrupts = <GIC_SPI 72 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&ccu CLK_BUS_EHCI0>, <&ccu CLK_BUS_OHCI0>;
+ 			resets = <&ccu RST_BUS_EHCI0>, <&ccu RST_BUS_OHCI0>;
++			phys = <&usbphy 0>;
++			phy-names = "usb";
+ 			status = "disabled";
+ 		};
+ 
+@@ -311,6 +313,8 @@
+ 			clocks = <&ccu CLK_BUS_EHCI0>, <&ccu CLK_BUS_OHCI0>,
+ 				 <&ccu CLK_USB_OHCI0>;
+ 			resets = <&ccu RST_BUS_EHCI0>, <&ccu RST_BUS_OHCI0>;
++			phys = <&usbphy 0>;
++			phy-names = "usb";
+ 			status = "disabled";
+ 		};
+ 
+diff --git a/configs/bananapi_p2_maker_defconfig b/configs/bananapi_p2_maker_defconfig
+new file mode 100644
+index 0000000000..1c3150323e
+--- /dev/null
++++ b/configs/bananapi_p2_maker_defconfig
+@@ -0,0 +1,13 @@
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_DEFAULT_DEVICE_TREE="sun8i-h2-plus-bananapi-p2-maker"
++CONFIG_SPL=y
++CONFIG_MACH_SUN8I_H3=y
++CONFIG_DRAM_CLK=408
++CONFIG_MMC0_CD_PIN=""
++# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_SPL_STACK=0x8000
++CONFIG_SYS_PBSIZE=1024
++CONFIG_SUN8I_EMAC=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_OHCI_HCD=y
+-- 
+2.36.0
+

--- a/boards/bananaPi-p2Maker/default.nix
+++ b/boards/bananaPi-p2Maker/default.nix
@@ -1,0 +1,19 @@
+{
+  device = {
+    manufacturer = "Banana Pi";
+    name = "P2 Maker";
+    identifier = "bananaPi-p2Maker";
+    productPageURL = "https://wiki.banana-pi.org/Banana_Pi_BPI-P2_Zero";
+  };
+
+  hardware = {
+    soc = "allwinner-h3";
+  };
+
+  Tow-Boot = {
+    defconfig = "bananapi_p2_maker_defconfig";
+    patches = [
+      ./0001-sunxi-add-Banana-Pi-P2-Maker.patch
+    ];
+  };
+}


### PR DESCRIPTION
The Banana Pi P2 Maker is a low-cost Allwinner H2+ (variant of the H3) development board primarily notable for having (optional) PoE. I've tested this with Arch Linux ARM, Debian, and Fedora, and all three work. It likely also would work with the P2 Zero, which uses the same PCB but with eMMC (and possibly support components for it?) populated, but of course without eMMC support. I initially attempted implementing the P2 Zero instead of the P2 Maker, but I wouldn't have been able to test the eMMC capabilities, and the missing eMMC caused warnings during boot.

The U-Boot patch could probably be upstreamed (especially the change to `sunxi-h3-h5.dtsi`, which is necessary for USB host functionality to work in U-Boot after a refactor), but I've had bad experiences submitting patches to these projects.