### PR TITLE
Dual eMMC boot support

### DIFF
--- a/modules/tow-boot/installer.nix
+++ b/modules/tow-boot/installer.nix
@@ -18,7 +18,13 @@ let
   ;
 
   inherit (config.hardware)
+    mmcBootAccess
+    mmcBootAck
+    mmcBootBusWidth
+    mmcBootBusWidthReset
     mmcBootIndex
+    mmcBootMode
+    mmcBootPart
   ;
 
   isPhoneUX = config.Tow-Boot.phone-ux.enable;
@@ -367,6 +373,19 @@ let
               echo "[ERROR] Failed to harden against failures."
               echo "        If is unknown whether rebooting is safe or not right now."
               ''}
+            fi
+
+            if [ ${mmcBootBusWidth} -ge 0 ] &&
+               [ ${mmcBootBusWidthReset} -ge 0 ] &&
+               [ ${mmcBootMode} -ge 0 ]; then
+              mmc bootbus ${mmcBootIndex} ${mmcBootBusWidth} ${mmcBootBusWidthReset} ${mmcBootMode}
+            fi
+            if [ ${mmcBootPart} ] &&
+               [ ${mmcBootAck} -ge 0 ]; then
+              if [ ${mmcBootPart} -eq 0 ] || [ ${mmcBootPart} -eq 7 ]; then
+                _bootpart = ${mmcBootPart}
+              fi
+              mmc partconf ${mmcBootIndex} ${mmcBootAck} $_bootpart ${mmcBootAccess}
             fi
           done
 

--- a/modules/tow-boot/installer.nix
+++ b/modules/tow-boot/installer.nix
@@ -317,53 +317,58 @@ let
           # Erasing the first 8KiB of the eMMC Boot Flash
           # With all tested devices, this is sufficient to neuter.
           # This helps ensure a failure in the following steps does not brick the device.
-          if mmc erase 0 $neutersize; then
+          for _bootpart in 2 1; do
+            mmc dev ${mmcBootIndex} $_bootpart
             echo ""
-            echo "   A stray reboot should be safe now."
-
-            echo ""
-            echo "-> Writing new firmware tail to eMMC Boot..."
-            if mmc write $new_firmware_addr_r_tail $neutersize $new_firmware_size_tail_blocks; then
+            echo "Preparing eMMC Boot partition '$_bootpart'"
+            if mmc erase 0 $neutersize; then
+              echo ""
+              echo "   A stray reboot should be safe now."
 
               echo ""
-              echo "-> Writing new firmware head to eMMC Boot..."
-              if mmc write $new_firmware_addr_r 0x0 $neutersize; then
-                ${config.Tow-Boot.installer.additionalMMCBootCommands}
+              echo "-> Writing new firmware tail to eMMC Boot..."
+              if mmc write $new_firmware_addr_r_tail $neutersize $new_firmware_size_tail_blocks; then
 
                 echo ""
-                echo "[SUCCESS] Flashing seems to have been successful!"
-                echo ""
-                if pause 'Press any key to reboot...'; then
-                  echo -n
+                echo "-> Writing new firmware head to eMMC Boot..."
+                if mmc write $new_firmware_addr_r 0x0 $neutersize; then
+                  ${config.Tow-Boot.installer.additionalMMCBootCommands}
+
+                  echo ""
+                  echo "[SUCCESS] Flashing seems to have been successful!"
+                  echo ""
+                  if pause 'Press any key to reboot...'; then
+                    echo -n
+                  else
+                    echo "Resetting in 5 seconds"
+                    sleep 5
+                  fi
+                  reset
+
+                # mmc write head
                 else
-                  echo "Resetting in 5 seconds"
-                  sleep 5
+                  ${error ''
+                  echo "[ERROR] Error flashing new firmware head to eMMC Boot."
+                  echo "        Rebooting now may fail."
+                  ''}
                 fi
-                reset
 
-              # mmc write head
+              # mmc write tail
               else
                 ${error ''
-                echo "[ERROR] Error flashing new firmware head to eMMC Boot."
-                echo "        Rebooting now may fail."
+                echo "[WARNING] Error flashing new firmware tail to eMMC Boot."
+                echo "          Rebooting now should be safe as the eMMC Boot was removed from the boot chain."
                 ''}
               fi
 
-            # mmc write tail
+            # mmc erase 0 0x2000
             else
               ${error ''
-              echo "[WARNING] Error flashing new firmware tail to eMMC Boot."
-              echo "          Rebooting now should be safe as the eMMC Boot was removed from the boot chain."
+              echo "[ERROR] Failed to harden against failures."
+              echo "        If is unknown whether rebooting is safe or not right now."
               ''}
             fi
-
-          # mmc erase 0 0x2000
-          else
-            ${error ''
-            echo "[ERROR] Failed to harden against failures."
-            echo "        If is unknown whether rebooting is safe or not right now."
-            ''}
-          fi
+          done
 
         # load Tow-Boot.mmcboot.bin
         else

--- a/modules/tow-boot/installer.nix
+++ b/modules/tow-boot/installer.nix
@@ -372,8 +372,7 @@ let
           echo "          Rebooting should be safe, nothing was done."
           ''}
         fi
-
-      # sf probe
+      # mmc dev
       else
         ${error ''
         echo "[WARNING] Running `mmc dev ${mmcBootIndex} 1` failed unexpectedly."


### PR DESCRIPTION
In issue #76 the desire to add eMMC boot support was brought up; however the current implementation is a little lacking.

the advantage of the eMMC boot partition, is that it comes in two, for redundancy purposes. Allowing for an update of it, without affecting the running one.

The behavior of which partition is being used, can be controlled in two ways. One that requires special support in the host (usually the BootROM) to either access the proper partitions, or to stream data from an eMMC. The later being interesting as it can significantly improve performance. For U-Boot however, this is not that interesting, the SPL is small enough that we'd be shaving off a few ms at best from the command overhead. The former, well requires special BootROM support which is not actually even needed.

The other way this can be controlled, is through the boot partition register (EXT_CSD 179). In this register, you tell the eMMC chip, to return data from the boot0 (or boot1, or user partition) to return data when the host issues a read command. This means no modification is needed to make use of the boot partition. It does require the eMMC chip to be set up appropriately using U-Boot's partconf.

The bootbus configuration is needed for performance reasons only.

As all this highly depends on the BootROM, eMMC chip and board layout, this can only be done via configuration variables.

Further more, all of this is useless without having U-Boot in two partitions, so this patch also ensures that U-Boot is actually installed in both partitions. The 'flipping' switching can be useful in various ways. the upgrade script first writes + verifies the second partition, then the first, and leverages partconf (or the mmc utils from Linux) to do so. Resulting in validated writes, never bricks.

One optimization that could be done as part of this commit also, is to actually make partconf use mandatory, and then remove the whole 'head/tail' mechanism, as it becomes useless. E.g. always write the in-active partition.

Due to lack of time, I haven't been able to quite test this well. But this methodology I have reliably used for more then 2 years in the field. For some supporting linux scriptage; see my U-Boot update script: https://gitlab.com/esbs/updater/-/blob/master/scripts/update_u-boot.sh#L411