### PR TITLE
Improved documentation when using serial

### DIFF
--- a/doc/development-guide.md
+++ b/doc/development-guide.md
@@ -43,7 +43,7 @@ I just want to build
 You still should read a bit more past this section, but if you absolutely only
 want to build, here's how you can build the `uBoot-sandbox` board.
 
-```
+```shell-session
  $ nix-build -A uBoot-sandbox
 ```
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -113,11 +113,9 @@ Many `AArch64` devices do not come with a display or can be used in headless mod
 
 In those cases, using serial to interact with the device can be required. Especially before your operating system of choice is loaded.
 
-Tow-Boot uses the same baud rate for all platforms and devices: `115200`
-Even platforms which generally default to another serial baud rate, have been configured to use the above for homogeneity.
+Tow-Boot uses the same baud rate for all platforms and devices: `115200` , even platforms which generally default to another serial baud rate, have been configured to use the above for homogeneity.
 
-You can use the serial console of your preference - `screen` , `picocom` , `minicom` and others.\
-The author personally uses `picocom` to access the serial console.
+You can use the serial console of your preference - `screen` , `picocom` , `minicom` and others.
 
 ### Examples for connecting with serial
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -121,16 +121,23 @@ You can use the serial console of your preference - `screen` , `picocom` , `mini
 
 Examples to connect to the device while installing or booting Tow-Boot from another device:
 
-```
-screen /dev/ttyUSB0 115200
-```
-
-```
-picocom /dev/ttyUSB0 -b 115200
+```shell-session
+$ screen /dev/ttyUSB0 115200
+...
+Press Ctrl+a and K to exit
 ```
 
+```shell-session
+$ picocom /dev/ttyUSB0 -b 115200
+...
+Press Ctrl+a and Ctrl+x to exit
 ```
-minicom -D /dev/ttyUSB0 -b 115200 
+
+```shell-session
+$ minicom -D /dev/ttyUSB0 -b 115200
+...
+
+Press Ctrl+a and X to exit
 ```
 
 To learn more, read the [*Differences from U-boot*](differences-from-u-boot.md) section.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -124,15 +124,15 @@ The author personally uses `picocom` to access the serial console.
 Examples to connect to the device while installing or booting Tow-Boot from another device:
 
 ```
-screen /dev/ttyUSB0 1500000
+screen /dev/ttyUSB0 115200
 ```
 
 ```
-picocom /dev/ttyUSB0 -b 1500000
+picocom /dev/ttyUSB0 -b 115200
 ```
 
 ```
-minicom -D /dev/ttyUSB0 -b 1500000 
+minicom -D /dev/ttyUSB0 -b 115200 
 ```
 
 To learn more, read the [*Differences from U-boot*](differences-from-u-boot.md) section.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -107,13 +107,13 @@ on.
 
 
 Serial 
------------------
+------
 
 Many `AArch64` devices do not come with a display or can be used in headless mode (as an example - a small home server which doesn't need a display).
 
 In those cases, using serial to interact with the device can be required. Especially before your operating system of choice is loaded.
 
-Tow-Boot uses the same baud rate for all platforms and devices: `115200` , even platforms which generally default to another serial baud rate, have been configured to use the above for homogeneity.
+Tow-Boot uses the same baud rate for all platforms and devices: `115200`. This applies to all platforms, even those which generally default to another serial baud rate.
 
 You can use the serial console of your preference - `screen` , `picocom` , `minicom` and others.
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -106,6 +106,38 @@ Using the *shared storage* strategy, you can simulate *dedicated storage* by
 on.
 
 
+Serial 
+-----------------
+
+Many `AArch64` devices do not come with a display or can be used in headless mode (as an example - a small home server which doesn't need a display).
+
+In those cases, using serial to interact with the device can be required. Especially before your operating system of choice is loaded.
+
+Tow-Boot uses the same baud rate for all platforms and devices: `115200`
+Even platforms which generally default to another serial baud rate, have been configured to use the above for homogeneity.
+
+You can use the serial console of your preference - `screen` , `picocom` , `minicom` and others.\
+The author personally uses `picocom` to access the serial console.
+
+### Examples for connecting with serial
+
+Examples to connect to the device while installing or booting Tow-Boot from another device:
+
+```
+screen /dev/ttyUSB0 1500000
+```
+
+```
+picocom /dev/ttyUSB0 -b 1500000
+```
+
+```
+minicom -D /dev/ttyUSB0 -b 1500000 
+```
+
+To learn more, read the [*Differences from U-boot*](differences-from-u-boot.md) section.
+
+
 Building Tow-Boot
 -----------------
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -115,7 +115,7 @@ In those cases, using serial to interact with the device can be required. Especi
 
 Tow-Boot uses the same baud rate for all platforms and devices: `115200`. This applies to all platforms, even those which generally default to another serial baud rate.
 
-You can use the serial console of your preference - `screen` , `picocom` , `minicom` and others.
+You can use the serial console software of your preference - `screen` , `picocom` , `minicom` and others.
 
 ### Examples for connecting with serial
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -136,7 +136,6 @@ Press Ctrl+a and Ctrl+x to exit
 ```shell-session
 $ minicom -D /dev/ttyUSB0 -b 115200
 ...
-
 Press Ctrl+a and X to exit
 ```
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -48,7 +48,7 @@ the storage media formatted in a specific manner.
 
 1. Write the `spi.installer.img` file to an SD card or another valid storage
    media for your particular board.
-   ```
+   ```shell-session
     # dd if=spi.installer.img of=/dev/XXX bs=1M oflag=direct,sync status=progress
    ```
 1. Boot the media on your board
@@ -59,7 +59,7 @@ the storage media formatted in a specific manner.
 
 1. Write the `mmcboot.installer.img` file to an SD card or another valid storage
    media for your particular board.
-   ```
+   ```shell-session
     # dd if=mmcboot.installer.img of=/dev/XXX bs=1M oflag=direct,sync status=progress
    ```
 1. Boot the media on your board
@@ -82,7 +82,7 @@ but the size has been chosen to allow further expansion if needed.
 
 1. Write the `shared.disk-image.img` file to an SD card or another valid storage
    media for your particular board.
-   ```
+   ```shell-session
     # dd if=shared.disk-image.img of=/dev/XXX bs=1M oflag=direct,sync status=progress
    ```
 
@@ -90,7 +90,7 @@ but the size has been chosen to allow further expansion if needed.
    disk before attempting any operations. Grow the GPT partition to the physical
    size of the medium. (This operation is a no-op that forces a rewrite of the
    partition table.)
-   ```
+   ```shell-session
     # sfdisk --append /dev/XXX
    ```
 

--- a/doc/serial.md
+++ b/doc/serial.md
@@ -8,6 +8,6 @@ to another serial baud rate have been configured for homogeneity.
 
 The author personally uses `picocom` to access the serial console.
 
-```
+```shell-session
  $ picocom -b 115200
 ```


### PR DESCRIPTION
As discussed in the comments of #180 - https://github.com/Tow-Boot/Tow-Boot/issues/180#issuecomment-1224327263 , submitting a PR with additions to the [getting-started.md](https://github.com/Tow-Boot/Tow-Boot/blob/released/doc/getting-started.md) page.

The goal is improve the experience of the end users.

`aarch64` SBCs can often rely on serial for their installation, monitoring or debugging.

In the case of RK3399 devices, the currently bundled `uboot` version with TowBoot has USB devices disabled making it impossible to interact with the installer without serial - RockPro64 is such example.