### PR TITLE
boards/RPi: switch to the u-boot aarch64 combined image

### DIFF
--- a/boards/raspberryPi-aarch64/default.nix
+++ b/boards/raspberryPi-aarch64/default.nix
@@ -17,6 +17,12 @@ let
     armstub=armstub8-gic.bin
     disable_overscan=1
 
+    [cm4]
+    dtoverlay=dwc2,dr_mode=host
+
+    [cm4s]
+    dtoverlay=dwc2,dr_mode=host
+
     [all]
     kernel=Tow-Boot.noenv.bin
     arm_64bit=1

--- a/support/overlay/overlay.nix
+++ b/support/overlay/overlay.nix
@@ -74,6 +74,8 @@ in
 
     meson64-tools = callPackage ./meson64-tools { };
 
+    raspberrypiFirmware = callPackage ./raspberrypi-firmware { };
+
     mkScript = file: final.runCommandNoCC "out.scr" {
       nativeBuildInputs = [
         final.buildPackages.ubootTools

--- a/support/overlay/raspberrypi-firmware/default.nix
+++ b/support/overlay/raspberrypi-firmware/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenvNoCC, fetchFromGitHub }:
+
+stdenvNoCC.mkDerivation rec {
+  # NOTE: this should be updated with linux_rpi
+  pname = "raspberrypi-firmware";
+  version = "1.20230106";
+
+  src = fetchFromGitHub {
+    owner = "raspberrypi";
+    repo = "firmware";
+    rev = version;
+    hash = "sha512-iKUR16RipN8BGAmXteTJUzd/P+m5gnbWCJ28LEzYfOTJnGSal63zI7LDQg/HIKXx9wMTARQKObeKn+7ioS4QkA==";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/raspberrypi/boot/overlays/
+
+    # Limit the files stored to only what we need
+    cp -v boot/bcm271[01]* $out/share/raspberrypi/boot/
+    cp -v boot/bootcode.bin boot/fixup*.dat boot/start*.elf $out/share/raspberrypi/boot/
+    cp -v boot/overlays/* $out/share/raspberrypi/boot/overlays/
+
+    # NOTICE: The license should be distributed along with the binaries
+    cp -v boot/LICENCE.broadcom $out/share/raspberrypi/boot/
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  meta = with lib; {
+    description = "Firmware for the Raspberry Pi board";
+    homepage = "https://github.com/raspberrypi/firmware";
+    license = licenses.unfreeRedistributableFirmware; # See https://github.com/raspberrypi/firmware/blob/master/boot/LICENCE.broadcom
+    maintainers = with maintainers; [ dezgeg ];
+    broken = stdenvNoCC.isDarwin; # Hash mismatch on source, mystery.
+  };
+}


### PR DESCRIPTION
The current version of the raspberryPi-aarch64 image only works on a couple of RaspberryPi boards: 3b and 4b.

Adding support for other boards can be achieved by using u-boot's `rpi_arm64_defconfig`, which supports:

 - Raspberry Pi 3b
 - Raspberry Pi 3b+
 - Raspberry Pi 4b
 - Raspberry Pi 400
 - Raspberry Pi CM 3
 - Raspberry Pi CM 3+
 - Raspberry Pi CM 4
 - Raspberry Pi zero 2 w

This however requires shipping the .dtb files along with the overlays inside the shared image, which this commit also adds.

Unfortunately, the raspberrypifw needs to be updated to achieve this goal, which explains why this commit is marked at WIP:

 - some of the .dtb files are currently missing
 - the start4.elf file is too old for the CM4