### PR TITLE
Pinephone Pro: Set GPIO4_PD3 as input

### DIFF
--- a/boards/odroid-C2/default.nix
+++ b/boards/odroid-C2/default.nix
@@ -11,8 +11,8 @@
 
 {
   device = {
-    manufacturer = "ODROID";
-    name = "C2";
+    manufacturer = "Hardkernel";
+    name = "ODROID-C2";
     identifier = "odroid-C2";
     productPageURL = "https://www.hardkernel.com/shop/odroid-c2/";
   };

--- a/boards/odroid-C4/README.md
+++ b/boards/odroid-C4/README.md
@@ -1,4 +1,4 @@
-# ODROID-C4
+# Hardkernel ODROID-C4
 
 ## Device-specific notes
 

--- a/boards/odroid-C4/default.nix
+++ b/boards/odroid-C4/default.nix
@@ -2,8 +2,8 @@
 
 {
   device = {
-    manufacturer = "ODROID";
-    name = "C4";
+    manufacturer = "Hardkernel";
+    name = "ODROID-C4";
     identifier = "odroid-C4";
     productPageURL = "https://www.hardkernel.com/shop/odroid-c4/";
   };

--- a/boards/odroid-N2/default.nix
+++ b/boards/odroid-N2/default.nix
@@ -2,8 +2,8 @@
 
 {
   device = {
-    manufacturer = "ODROID";
-    name = "N2";
+    manufacturer = "Hardkernel";
+    name = "ODROID-N2";
     identifier = "odroid-N2";
     productPageURL = "https://www.hardkernel.com/shop/odroid-n2-with-4gbyte-ram-2/";
   };

--- a/boards/pine64-pinephonePro/0001-rk_gpio-Added-spl_gpio_input-method.patch
+++ b/boards/pine64-pinephonePro/0001-rk_gpio-Added-spl_gpio_input-method.patch
@@ -1,0 +1,38 @@
+From 893c24bbe0f5d738641a19337df0ce29e65946b4 Mon Sep 17 00:00:00 2001
+From: Antoni Przybylik <antoni.przybylik@wp.pl>
+Date: Wed, 21 Sep 2022 22:20:49 +0200
+Subject: [PATCH 1/9] rk_gpio: Added spl_gpio_input method
+
+This patch adds spl_gpio_input method for rk_gpio.
+
+Signed-off-by: Antoni Przybylik <antoni.przybylik@wp.pl>
+---
+ drivers/gpio/rk_gpio.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/drivers/gpio/rk_gpio.c b/drivers/gpio/rk_gpio.c
+index 68f30157a9..8883fa14eb 100644
+--- a/drivers/gpio/rk_gpio.c
++++ b/drivers/gpio/rk_gpio.c
+@@ -125,6 +125,18 @@ int spl_gpio_set_pull(void *vregs, uint gpio, int pull)
+ 	return 0;
+ }
+ 
++int spl_gpio_input(void *vregs, uint gpio)
++{
++	struct rockchip_gpio_regs * const regs = vregs;
++
++	clrsetbits_le32(&regs->swport_dr, 1 << gpio, 0);
++
++	/* Set direction */
++	clrsetbits_le32(&regs->swport_ddr, 1 << gpio, 0);
++
++	return 0;
++}
++
+ int spl_gpio_output(void *vregs, uint gpio, int value)
+ {
+ 	struct rockchip_gpio_regs * const regs = vregs;
+-- 
+2.37.3
+

--- a/boards/pine64-pinephonePro/0009-Pinephone-Pro-Set-GPIO4_PD3-as-input.patch
+++ b/boards/pine64-pinephonePro/0009-Pinephone-Pro-Set-GPIO4_PD3-as-input.patch
@@ -1,0 +1,49 @@
+From fc93f2763e5218c58666228cead3634360940fac Mon Sep 17 00:00:00 2001
+From: Antoni Przybylik <antoni.przybylik@wp.pl>
+Date: Wed, 21 Sep 2022 23:43:53 +0200
+Subject: [PATCH 9/9] Pinephone Pro: Set GPIO4_PD3 as input
+
+STK3311 driver expects this pin set as input.
+
+Signed-off-by: Antoni Przybylik <antoni.przybylik@wp.pl>
+---
+ arch/arm/mach-rockchip/rk3399/rk3399.c                 |  1 +
+ .../pine64/pinephone-pro-rk3399/pinephone-pro-rk3399.c | 10 ++++++++++
+ 2 files changed, 11 insertions(+)
+
+diff --git a/arch/arm/mach-rockchip/rk3399/rk3399.c b/arch/arm/mach-rockchip/rk3399/rk3399.c
+index 21db03b961..5dd3e14cf1 100644
+--- a/arch/arm/mach-rockchip/rk3399/rk3399.c
++++ b/arch/arm/mach-rockchip/rk3399/rk3399.c
+@@ -252,6 +252,7 @@ void __weak led_setup(void)
+ void spl_board_init(void)
+ {
+ 	led_setup();
++	setup_gpio_pins();
+ 
+ #if defined(SPL_GPIO)
+ 	struct rockchip_cru *cru = rockchip_get_cru();
+diff --git a/board/pine64/pinephone-pro-rk3399/pinephone-pro-rk3399.c b/board/pine64/pinephone-pro-rk3399/pinephone-pro-rk3399.c
+index 22c2ced2d7..1684fb8ebd 100644
+--- a/board/pine64/pinephone-pro-rk3399/pinephone-pro-rk3399.c
++++ b/board/pine64/pinephone-pro-rk3399/pinephone-pro-rk3399.c
+@@ -57,6 +57,16 @@ int misc_init_r(void)
+ 	return ret;
+ }
+ 
++void setup_gpio_pins(void)
++{
++	struct rockchip_gpio_regs * const gpio4 = (void *)GPIO4_BASE;
++
++	/* BROM leaves GPIO4_PD3 enabled as output for some unknown reason,
++	 * and this breaks kernel expectations. (STK3311 probe on PPP).
++	 * Set GPIO4_PD3 to input direction. */
++	spl_gpio_input(gpio4, GPIO(BANK_D, 3));
++}
++
+ void led_setup(void)
+ {
+ 	struct rockchip_gpio_regs * const gpio3 = (void *)GPIO3_BASE;
+-- 
+2.37.3
+

--- a/boards/pine64-pinephonePro/default.nix
+++ b/boards/pine64-pinephonePro/default.nix
@@ -75,6 +75,8 @@
 
       ./0001-pine64-pinephonepro-device-enablement.patch
       ./0001-rk3399-pinephone-pro-add-smbios-info.patch
+      ./0001-rk_gpio-Added-spl_gpio_input-method.patch
+      ./0009-Pinephone-Pro-Set-GPIO4_PD3-as-input.patch
     ];
   };
   documentation.sections.installationInstructions = builtins.readFile ./INSTALLING.md;


### PR DESCRIPTION
Good afternoon,

Setting GPIO4_PD3 as input is necessary for STK3311 sensor driver to function properly. That's what megi is doing in levinboot -- https://xff.cz/git/levinboot/commit/?id=6de55d9d4e991e9f261b4e323dfa8b0682cbe9e0

I did not have a chance to test it yet, will keep you informed about any progress on this.

Antoni Przybylik