### PR TITLE
i2c: rockchip: De-initialize the bus after start bit failure

### DIFF
--- a/boards/pine64-pinephonePro/default.nix
+++ b/boards/pine64-pinephonePro/default.nix
@@ -81,6 +81,13 @@
         url = "https://xff.cz/git/u-boot/patch/?id=7f8238fd608290152b143322178a5be21a447dc1";
         sha256 = "sha256-B3B6AQqiQ0NbdVZ4Xu1UOotCDJCZgJcYGJlQKrORb6U=";
       })
+
+      # i2c: rockchip: De-initialize the bus after start bit failure
+      # https://xff.cz/git/u-boot/commit/?h=ppp&id=ccb804db1753958a33e7a6e55c52b3b04e4754e9
+      (pkgs.fetchpatch {
+        url = "https://xff.cz/git/u-boot/patch/?id=ccb804db1753958a33e7a6e55c52b3b04e4754e9";
+        sha256 = "sha256-Gzl5QHlM2pITnFjHaPwn0T08R75V8oeAumoH+h1PMEo=";
+      })
     ];
   };
   documentation.sections.installationInstructions = builtins.readFile ./INSTALLING.md;


### PR DESCRIPTION
Failure can happen when i2c is used without initializing pinctrl properly, which U-Boot happily allows. Without this fix, further I2C access would fail, even after proper pinctrl initialization.

This is based on megi's u-boot (see
https://xff.cz/git/u-boot/commit/?h=ppp&id=ccb804db1753958a33e7a6e55c52b3b04e4754e9)

It compiles, but I did not test it on real hardware yet.

Antoni Przybylik