### PR TITLE
radxa-RockPi4: Fix USB keyboard not working

### DIFF
--- a/boards/radxa-RockPi4/default.nix
+++ b/boards/radxa-RockPi4/default.nix
@@ -20,6 +20,8 @@
       ./0001-rockpi4-rk3399-add-spi-support.patch
       # From https://github.com/armbian/build/blob/master/patch/u-boot/u-boot-rockchip64/general-add-xtx-spi-nor-chips.patch
       ./general-add-xtx-spi-nor-chips.patch
+      # From https://www.mail-archive.com/u-boot@lists.denx.de/msg371891.html
+      ./preboot-usb-start.patch
     ];
   };
 }

--- a/boards/radxa-RockPi4/preboot-usb-start.patch
+++ b/boards/radxa-RockPi4/preboot-usb-start.patch
@@ -1,0 +1,27 @@
+Patch-Source: https://www.mail-archive.com/u-boot@lists.denx.de/msg371891.html
+
+This patch fixes a problem with USB keyboard not working in the boot menu.
+I tested it on ROCK Pi 4 B+ and it works, but the keyboard must be connected
+to one of the *blue* USB ports.
+--
+From: Marcin Juszkiewicz <marcin@juszkiewicz.com.pl>
+Date: Wed, 3 Jan 2020 12:45:26 +0700
+Subject: [PATCH] rockchip: rockpro64: initialize USB in preboot
+
+With video output enabled and USB keyboard supported there is no need
+for serial console. So let initialize USB subsystem so keyboard connected to
+board (either directly or via hub) can be used to interrupt autoboot.
+
+diff --git a/configs/rock-pi-4-rk3399_defconfig b/configs/rock-pi-4-rk3399_defconfig
+index f01b6a3935..b2de4e4cfb 100644
+--- a/configs/rock-pi-4-rk3399_defconfig
++++ b/configs/rock-pi-4-rk3399_defconfig
+@@ -10,6 +10,8 @@ CONFIG_DEBUG_UART_BASE=0xFF1A0000
+ CONFIG_DEBUG_UART_CLOCK=24000000
+ CONFIG_DEBUG_UART=y
+ # CONFIG_ANDROID_BOOT_IMAGE is not set
++CONFIG_USE_PREBOOT=y
++CONFIG_PREBOOT="usb start"
+ CONFIG_DEFAULT_FDT_FILE="rockchip/rk3399-rock-pi-4b.dtb"
+ CONFIG_DISPLAY_BOARDINFO_LATE=y
+ CONFIG_MISC_INIT_R=y

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -17,6 +17,9 @@ in
       let
         patchSets = {
           "2021.10" = let base = ../../support/u-boot/2021.10/patches; in [
+            # Patches backported from upstream
+            (base + "/0001-usb-xhci-reset-endpoint-on-USB-stall.patch")
+
             # Misc patches to upstream
             (base + "/0001-cmd-Add-pause-command.patch")
             (base + "/0001-cmd-env-Add-indirect-to-indirectly-set-values.patch")

--- a/support/u-boot/2021.10/patches/0001-usb-xhci-reset-endpoint-on-USB-stall.patch
+++ b/support/u-boot/2021.10/patches/0001-usb-xhci-reset-endpoint-on-USB-stall.patch
@@ -1,0 +1,84 @@
+Patch-Source: https://github.com/u-boot/u-boot/commit/d5daa02d8d9e7c403a3339db1966e8413e64e408
+See-Also: https://lore.kernel.org/all/3d4ece94-932a-25dd-ef29-0ddfb4a51465@denx.de/T/
+--
+From d5daa02d8d9e7c403a3339db1966e8413e64e408 Mon Sep 17 00:00:00 2001
+From: Stefan Agner <stefan@agner.ch>
+Date: Mon, 27 Sep 2021 14:42:58 +0200
+Subject: [PATCH] usb: xhci: reset endpoint on USB stall
+
+There are devices which cause a USB stall when trying to read strings.
+Specifically Arduino Mega R3 stalls when trying to read the product
+string.
+
+The stall currently remains unhandled, and subsequent retries submit new
+transfers on a stopped endpoint which ultimately cause a crash in
+abort_td():
+WARN halted endpoint, queueing URB anyway.
+XHCI control transfer timed out, aborting...
+Unexpected XHCI event TRB, skipping... (3affe040 00000000 13000000 02008401)
+BUG at drivers/usb/host/xhci-ring.c:505/abort_td()!
+BUG!
+resetting ...
+
+Linux seems to be able to recover from the stall by issuing a
+TRB_RESET_EP command.
+
+Introduce reset_ep() which issues a TRB_RESET_EP followed by setting the
+transfer ring dequeue pointer via TRB_SET_DEQ. This allows to properly
+recover from a USB stall error and continue communicating with the USB
+device.
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ drivers/usb/host/xhci-ring.c | 31 +++++++++++++++++++++++++++++++
+ 1 file changed, 31 insertions(+)
+
+diff --git a/drivers/usb/host/xhci-ring.c b/drivers/usb/host/xhci-ring.c
+index 0b3e7a2f5502..eb6dfcdb09e9 100644
+--- a/drivers/usb/host/xhci-ring.c
++++ b/drivers/usb/host/xhci-ring.c
+@@ -481,6 +481,33 @@ union xhci_trb *xhci_wait_for_event(struct xhci_ctrl *ctrl, trb_type expected)
+ 	BUG();
+ }
+ 
++/*
++ * Send reset endpoint command for given endpoint. This recovers from a
++ * halted endpoint (e.g. due to a stall error).
++ */
++static void reset_ep(struct usb_device *udev, int ep_index)
++{
++	struct xhci_ctrl *ctrl = xhci_get_ctrl(udev);
++	struct xhci_ring *ring =  ctrl->devs[udev->slot_id]->eps[ep_index].ring;
++	union xhci_trb *event;
++	u32 field;
++
++	printf("Resetting EP %d...\n", ep_index);
++	xhci_queue_command(ctrl, NULL, udev->slot_id, ep_index, TRB_RESET_EP);
++	event = xhci_wait_for_event(ctrl, TRB_COMPLETION);
++	field = le32_to_cpu(event->trans_event.flags);
++	BUG_ON(TRB_TO_SLOT_ID(field) != udev->slot_id);
++	xhci_acknowledge_event(ctrl);
++
++	xhci_queue_command(ctrl, (void *)((uintptr_t)ring->enqueue |
++		ring->cycle_state), udev->slot_id, ep_index, TRB_SET_DEQ);
++	event = xhci_wait_for_event(ctrl, TRB_COMPLETION);
++	BUG_ON(TRB_TO_SLOT_ID(le32_to_cpu(event->event_cmd.flags))
++		!= udev->slot_id || GET_COMP_CODE(le32_to_cpu(
++		event->event_cmd.status)) != COMP_SUCCESS);
++	xhci_acknowledge_event(ctrl);
++}
++
+ /*
+  * Stops transfer processing for an endpoint and throws away all unprocessed
+  * TRBs by setting the xHC's dequeue pointer to our enqueue pointer. The next
+@@ -928,6 +955,10 @@ int xhci_ctrl_tx(struct usb_device *udev, unsigned long pipe,
+ 
+ 	record_transfer_result(udev, event, length);
+ 	xhci_acknowledge_event(ctrl);
++	if (udev->status == USB_ST_STALLED) {
++		reset_ep(udev, ep_index);
++		return -EPIPE;
++	}
+ 
+ 	/* Invalidate buffer to make it available to usb-core */
+ 	if (length > 0)


### PR DESCRIPTION
Note: On ROCK Pi 4B+, the keyboard must be connected to one of the *blue* USB ports.

Fixes #147