### PR TITLE
u-boot/patches: Identify as Tow-Boot in TPL/SPL, SMBIOS, and drop date

### DIFF
--- a/support/u-boot/2022.07/patches/0001-treewide-Identify-as-Tow-Boot.patch
+++ b/support/u-boot/2022.07/patches/0001-treewide-Identify-as-Tow-Boot.patch
@@ -50,3 +50,124 @@ index 83ac583e0b4..89d7a2b538a 100644
 -- 
 2.35.1
 
+From 9e9180730ba468de298084d942d7847f5a349f43 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Sun, 4 Sep 2022 17:47:53 -0400
+Subject: [PATCH 1/3] smbios: identify as Tow-Boot and expose full version
+ string
+
+The SMBIOS spec states for BIOS Version:
+
+> String number of the BIOS Version. This value is a free-form string
+> that may contain Core and OEM version information.
+
+I think this is the perfect string to use here.
+
+Changing the vendor here is not meant to fake that we're not U-Boot,
+but means that we correctly signal that the behaviour may differ from
+upstream U-Boot. This is important, we don't want users going to the
+exposed vendor (e.g. U-Boot) and tying up their ressources on issues
+of a forked project.
+---
+ lib/smbios.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/lib/smbios.c b/lib/smbios.c
+index 1e6497fa934..8e99e525c98 100644
+--- a/lib/smbios.c
++++ b/lib/smbios.c
+@@ -14,6 +14,7 @@
+ #include <sysinfo.h>
+ #include <tables_csum.h>
+ #include <version.h>
++#include <version_string.h>
+ #ifdef CONFIG_CPU
+ #include <cpu.h>
+ #include <dm/uclass-internal.h>
+@@ -253,11 +254,10 @@ static int smbios_write_type0(ulong *current, int handle,
+ 	memset(t, 0, sizeof(struct smbios_type0));
+ 	fill_smbios_header(t, SMBIOS_BIOS_INFORMATION, len, handle);
+ 	smbios_set_eos(ctx, t->eos);
+-	t->vendor = smbios_add_string(ctx, "U-Boot");
++	t->vendor = smbios_add_string(ctx, "Tow-Boot");
+ 
+-	t->bios_ver = smbios_add_prop(ctx, "version");
+-	if (!t->bios_ver)
+-		t->bios_ver = smbios_add_string(ctx, PLAIN_VERSION);
++	/* Hardcode full version string */
++	t->bios_ver = smbios_add_string(ctx, version_string);
+ 	if (t->bios_ver)
+ 		gd->smbios_version = ctx->last_str;
+ 	log_debug("smbios_version = %p: '%s'\n", gd->smbios_version,
+-- 
+2.38.0
+
+
+From 58f192f50314f36c10bbe67daf9001dda2c33ed8 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Sun, 4 Sep 2022 18:09:34 -0400
+Subject: [PATCH 2/3] version: Drop date from full version string
+
+---
+ cmd/version.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/cmd/version.c b/cmd/version.c
+index f83f6aff92c..a87a6ddfd6e 100644
+--- a/cmd/version.c
++++ b/cmd/version.c
+@@ -14,8 +14,7 @@
+ #include <asm/cb_sysinfo.h>
+ #endif
+ 
+-#define U_BOOT_VERSION_STRING U_BOOT_VERSION " (" U_BOOT_DATE " - " \
+-	U_BOOT_TIME " " U_BOOT_TZ ")" CONFIG_IDENT_STRING
++#define U_BOOT_VERSION_STRING U_BOOT_VERSION " " CONFIG_IDENT_STRING
+ 
+ const char version_string[] = U_BOOT_VERSION_STRING;
+ 
+-- 
+2.38.0
+
+
+From e298348d7db365b4c7d381c6d266cafeb0e65104 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Sun, 4 Sep 2022 18:11:34 -0400
+Subject: [PATCH 3/3] spl/tpl: Identify as Tow-Boot and drop date
+
+---
+ arch/arm/mach-rockchip/tpl.c | 3 +--
+ common/spl/spl.c             | 3 +--
+ 2 files changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm/mach-rockchip/tpl.c b/arch/arm/mach-rockchip/tpl.c
+index ed46a9ad286..088fa6c1475 100644
+--- a/arch/arm/mach-rockchip/tpl.c
++++ b/arch/arm/mach-rockchip/tpl.c
+@@ -66,8 +66,7 @@ void board_init_f(ulong dummy)
+ 	 */
+ 	debug_uart_init();
+ #ifdef CONFIG_TPL_BANNER_PRINT
+-	printascii("\nU-Boot TPL " PLAIN_VERSION " (" U_BOOT_DATE " - " \
+-				U_BOOT_TIME ")\n");
++	printascii("\nTow-Boot " SPL_TPL_NAME " " PLAIN_VERSION "\n");
+ #endif
+ #endif
+ 	ret = spl_early_init();
+diff --git a/common/spl/spl.c b/common/spl/spl.c
+index c8c463f80bd..b56a56ea705 100644
+--- a/common/spl/spl.c
++++ b/common/spl/spl.c
+@@ -879,8 +879,7 @@ void preloader_console_init(void)
+ 	gd->have_console = 1;
+ 
+ #if CONFIG_IS_ENABLED(BANNER_PRINT)
+-	puts("\nU-Boot " SPL_TPL_NAME " " PLAIN_VERSION " (" U_BOOT_DATE " - "
+-	     U_BOOT_TIME " " U_BOOT_TZ ")\n");
++	puts("\nTow-Boot " SPL_TPL_NAME " " PLAIN_VERSION "\n");
+ #endif
+ #ifdef CONFIG_SPL_DISPLAY_PRINT
+ 	spl_display_print();
+-- 
+2.38.0
+


### PR DESCRIPTION
Again, this is not meant to erase the hard work from U-Boot, but to correctly message to the user and people helping people that this is not exactly U-Boot, so things may differ.

If it wasn't for the fact it would get unwieldy, and a bad idea, I would take inspiration from HTTP User-Agents and have something like `U-Boot (Tow-Boot -006) 2022.07`. But it's not like anything is scripting against the `U-Boot` identifier here. And if they are, it likely needs to be discouraged.

Other than the early logs in TPL and SPL, this can be observed as such in SMBIOS information when booted through UEFI:

```
/sys/class/dmi/id/bios_vendor:Tow-Boot
/sys/class/dmi/id/bios_version:Tow-Boot 2022.07 006-pre [variant: mmcboot]
```

This allows identifying exactly what was used to boot the operating system.