### PR TITLE
u-boot/patches: Add more correct chassis information in SMBIOS

### DIFF
--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -65,6 +65,7 @@ in
           "2022.07" = let base = ../../support/u-boot/2022.07/patches; in [
             # Misc patches to upstream
             (base + "/0001-sunxi-Use-mmc_get_env_dev-only-if-relevant.patch")
+            (base + "/0001-smbios-enclosure-support.patch")
 
             # Misc patches being upstreamed
             (base + "/0001-cmd-Add-pause-command.patch")

--- a/support/u-boot/2022.07/patches/0001-smbios-enclosure-support.patch
+++ b/support/u-boot/2022.07/patches/0001-smbios-enclosure-support.patch
@@ -1,0 +1,103 @@
+From c23c8f5ab4826d6d85024313abca2d51fc14d3be Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Sun, 4 Sep 2022 17:50:47 -0400
+Subject: [PATCH 1/2] smbios: Add more in-use enclosure types
+
+---
+ include/smbios.h | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/include/smbios.h b/include/smbios.h
+index c9df2706f5a..17725bdbd16 100644
+--- a/include/smbios.h
++++ b/include/smbios.h
+@@ -116,7 +116,17 @@ struct __packed smbios_type2 {
+ 	char eos[SMBIOS_STRUCT_EOS_BYTES];
+ };
+ 
+-#define SMBIOS_ENCLOSURE_DESKTOP	3
++/* Definitions limited to those required by the implementation */
++#define SMBIOS_ENCLOSURE_OTHER               0x01 /* Other */
++#define SMBIOS_ENCLOSURE_UNKNOWN             0x02 /* Unknown */
++#define SMBIOS_ENCLOSURE_DESKTOP             0x03 /* Desktop */
++#define SMBIOS_ENCLOSURE_LAPTOP              0x09 /* Laptop */
++#define SMBIOS_ENCLOSURE_HAND_HELD           0x0B /* Hand Held */
++#define SMBIOS_ENCLOSURE_MAIN_SERVER_CHASSIS 0x11 /* Main Server Chassis */
++#define SMBIOS_ENCLOSURE_TABLET              0x1E /* Tablet */
++#define SMBIOS_ENCLOSURE_CONVERTIBLE         0x1F /* Convertible */
++#define SMBIOS_ENCLOSURE_EMBEDDED_PC         0x22 /* Embedded PC */
++
+ #define SMBIOS_STATE_SAFE		3
+ #define SMBIOS_SECURITY_NONE		3
+ 
+-- 
+2.38.0
+
+
+From a6a720b9e6c0e0b76c5819263a482a99fc74429f Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Sun, 4 Sep 2022 17:54:12 -0400
+Subject: [PATCH 2/2] smbios: Use device tree /chassis-type as source of truth
+
+---
+ lib/smbios.c | 37 ++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 36 insertions(+), 1 deletion(-)
+
+diff --git a/lib/smbios.c b/lib/smbios.c
+index d7f4999e8b2..1e6497fa934 100644
+--- a/lib/smbios.c
++++ b/lib/smbios.c
+@@ -87,6 +87,31 @@ struct smbios_write_method {
+ 	const char *subnode_name;
+ };
+ 
++/**
++ * smbios_enclosure_from_string() - returns smbios byte value for chassis type string.
++ *
++ * The chassis type string values are the recommended root node properties as
++ * defined in the device tree specification 3.2 Root node.
++ *
++ * The byte values are the closest equivalent values as defined in the SMBIOS
++ * specification, 7.4.1 System Enclosure or Chassis Types.
++ */
++static int smbios_enclosure_from_string(char* str)
++{
++	if (!strncmp(str, "desktop", 7)) return SMBIOS_ENCLOSURE_DESKTOP;
++	if (!strncmp(str, "laptop", 6)) return SMBIOS_ENCLOSURE_LAPTOP;
++	if (!strncmp(str, "convertible", 11)) return SMBIOS_ENCLOSURE_CONVERTIBLE;
++	if (!strncmp(str, "server", 6)) return SMBIOS_ENCLOSURE_MAIN_SERVER_CHASSIS;
++	if (!strncmp(str, "tablet", 6)) return SMBIOS_ENCLOSURE_TABLET;
++	/* Hand Held is the closest there is */
++	if (!strncmp(str, "handset", 7)) return SMBIOS_ENCLOSURE_HAND_HELD;
++	/* SMBIOS does not define watch */
++	if (!strncmp(str, "watch", 5)) return SMBIOS_ENCLOSURE_OTHER;
++	if (!strncmp(str, "embedded", 8)) return SMBIOS_ENCLOSURE_EMBEDDED_PC;
++	
++	return SMBIOS_ENCLOSURE_UNKNOWN;
++}
++
+ /**
+  * smbios_add_string() - add a string to the string area
+  *
+@@ -346,7 +371,17 @@ static int smbios_write_type3(ulong *current, int handle,
+ 	t->manufacturer = smbios_add_prop(ctx, "manufacturer");
+ 	if (!t->manufacturer)
+ 		t->manufacturer = smbios_add_string(ctx, "Unknown");
+-	t->chassis_type = SMBIOS_ENCLOSURE_DESKTOP;
++	t->chassis_type = SMBIOS_ENCLOSURE_UNKNOWN;
++	if (IS_ENABLED(CONFIG_OF_CONTROL)) {
++		ofnode node;
++		node = ofnode_path("/");
++		const char *chassis_type;
++
++		if (ofnode_valid(node)) {
++			chassis_type = ofnode_read_string(node, "chassis-type");
++			t->chassis_type = smbios_enclosure_from_string(chassis_type);
++		}
++	}
+ 	t->bootup_state = SMBIOS_STATE_SAFE;
+ 	t->power_supply_state = SMBIOS_STATE_SAFE;
+ 	t->thermal_state = SMBIOS_STATE_SAFE;
+-- 
+2.38.0
+


### PR DESCRIPTION
The information cannot map 1-to-1 with the device tree values in SMBIOS, so the closest values are used.

On a Pinebook (A64)

```
/sys/class/dmi/id/chassis_type:9
```

Which maps to

```
#define SMBIOS_ENCLOSURE_LAPTOP              0x09 /* Laptop */
```
