### PR TITLE
radxa-RockPi4: Enable USB support at boot

### DIFF
--- a/boards/radxa-RockPi4/default.nix
+++ b/boards/radxa-RockPi4/default.nix
@@ -15,6 +15,12 @@
 
   Tow-Boot = {
     defconfig = lib.mkDefault "rock-pi-4-rk3399_defconfig";
+    config = [
+      (helpers: with helpers; {
+        USE_PREBOOT = yes;
+        PREBOOT = freeform ''"usb start"'';
+      })
+    ];
     patches = [
       # Based on https://github.com/armbian/build/blob/master/patch/u-boot/u-boot-rockchip64/board-rock-pi-4-enable-spi-flash.patch
       ./0001-rockpi4-rk3399-add-spi-support.patch


### PR DESCRIPTION
This also intrinsically applies to the Rock Pi 4C.

I was unable to test, but this is verified to affect the build by looking at the `config` files in the result folder.


cc @jirutka

Supersedes and closes #199