### PR TITLE
.github: Fix docs workflow regression

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,15 +7,12 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: cachix/install-nix-action@v13
-        with:
-          install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
-          extra_nix_config: |
+      - uses: DeterminateSystems/nix-installer-action@v4
       - run: nix-build doc/
       - if: success()
         uses: crazy-max/ghaction-github-pages@v2


### PR DESCRIPTION
Using ubuntu-latest might not have been a wise choice.

Let's also switch to Determinate System's action for Nix. (In turn updating the Nix release in use.)

> ***NOTE***: For non-Nix-aware people, this only updates the evaluator/builder system; the evaluation still uses the same pinned Nixpkgs version, so this change does not change any of the behaviour.


### What was done

 - [Tested on the branch with a now-disappeared commit, successfully](https://github.com/samueldr/Tow-Boot/actions/runs/5447857757).