### PR TITLE
tow-boot/phone-ux: Ensure LED_STATUS doesn't claim LEDs

### DIFF
--- a/modules/tow-boot/phone-ux.nix
+++ b/modules/tow-boot/phone-ux.nix
@@ -173,6 +173,8 @@ in
           (helpers: with helpers; {
             LED = yes;
             CMD_LED = yes;
+            # Conflicts with `led` command by claiming the device.
+            LED_STATUS = no;
           })
           (helpers: with helpers; {
             VIBRATOR = yes;


### PR DESCRIPTION
The (newer?) `led` command can't claim and use the LEDs when the `LED_STATUS` subsystem configured it in SPL.

For now, rely on the previous behaviour.

This fixes an issue reported in the matrix room by `Aren`. The green LED on the Pinephone (A64) could not be used by the `led` command anymore.