### PR TITLE
Make it work in pure evaluation mode

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -33,8 +33,6 @@ let
 
   outputs = builtins.listToAttrs (builtins.map (device: { name = device; value = evalFor device; }) allDevices);
   outputsCount = builtins.length (builtins.attrNames outputs);
-
-  pkgs = import ./nixpkgs.nix {};
 in
 
 outputs // {


### PR DESCRIPTION
Otherwise Tow-Boot cannot be used from flakes.