### PR TITLE
arm-trusted-firmware: 2.6 -> 2.9

### DIFF
--- a/support/overlay/arm-trusted-firmware/default.nix
+++ b/support/overlay/arm-trusted-firmware/default.nix
@@ -15,7 +15,7 @@ let
             , platform ? null
             , extraMakeFlags ? []
             , extraMeta ? {}
-            , version ? "2.6"
+            , version ? "2.9"
             , ... } @ args:
            stdenv.mkDerivation ({
 
@@ -26,7 +26,7 @@ let
       owner = "ARM-software";
       repo = "arm-trusted-firmware";
       rev = "v${version}";
-      sha256 = "sha256-qT9DdTvMcUrvRzgmVf2qmKB+Rb1WOB4p1rM+fsewGcg=";
+      sha256 = "sha256-F7RNYNLh0ORzl5PmzRX9wGK8dZgUQVLKQg1M9oNd0pk=";
     };
 
     depsBuildBuild = [ buildPackages.stdenv.cc ];
@@ -70,12 +70,11 @@ in {
   armTrustedFirmwareTools = buildArmTrustedFirmware rec {
     extraMakeFlags = [
       "HOSTCC=${stdenv.cc.targetPrefix}gcc"
-      "fiptool" "certtool" "sptool"
+      "fiptool" "certtool"
     ];
     filesToInstall = [
       "tools/fiptool/fiptool"
       "tools/cert_create/cert_create"
-      "tools/sptool/sptool"
     ];
     postInstall = ''
       mkdir -p "$out/bin"


### PR DESCRIPTION
I'm not sure why exactly, but this seems to be needed to get cpuidle working on pine64-pinephoneA64.

I've tested on the pinephone to make sure it still boots from emmc and sd and that cpuidle is now working (with the hacks that distros are using), but I don't have the hardware to test anything else.

I also removed sptool from the armTrustedFirmwareTools package because it's been rewritten in python, requiring adding extra dependencies, and it doesn't appear to be used.