### PR TITLE
Add stock U-Boot refs up to 2023.07

### DIFF
--- a/modules/tow-boot/builder.nix
+++ b/modules/tow-boot/builder.nix
@@ -180,9 +180,11 @@ in
           ] ++ makeFlags;
 
           # Inject defines for things lacking actual configuration options.
-          NIX_CFLAGS_COMPILE = optionals withLogo [
-            "-DCONFIG_SYS_VIDEO_LOGO_MAX_SIZE=${toString (1920*1080*4)}"
-          ];
+          NIX_CFLAGS_COMPILE =
+            (optionals withLogo (
+              lib.optional (lib.versionOlder uBootVersion "2023.01") "-DCONFIG_SYS_VIDEO_LOGO_MAX_SIZE=${config.Tow-Boot.VIDEO_LOGO_MAX_SIZE}"
+            ))
+          ;
 
           extraConfig = ''
             #

--- a/modules/tow-boot/config.nix
+++ b/modules/tow-boot/config.nix
@@ -70,7 +70,7 @@ in
       CMD_BDI = yes;
       CMD_CLS = yes;
       CMD_SETEXPR = yes;
-      CMD_PAUSE = lib.mkIf (!config.Tow-Boot.buildUBoot) yes;
+      CMD_PAUSE = mkIf (!config.Tow-Boot.buildUBoot || versionAtLeast config.Tow-Boot.uBootVersion "2023.01") yes;
       CMD_POWEROFF = lib.mkDefault yes;
       CMD_NVEDIT_INDIRECT =
         mkIf (versionAtLeast config.Tow-Boot.uBootVersion "2022.07") yes

--- a/modules/tow-boot/config.nix
+++ b/modules/tow-boot/config.nix
@@ -154,6 +154,7 @@ in
       BMP_24BPP = yes;
       BMP_32BPP = yes;
       SPLASH_SOURCE = no;
+      VIDEO_LOGO_MAX_SIZE = mkIf (versionAtLeast config.Tow-Boot.uBootVersion "2023.01") (freeform config.Tow-Boot.VIDEO_LOGO_MAX_SIZE);
     }))
   ];
 }

--- a/modules/tow-boot/config.nix
+++ b/modules/tow-boot/config.nix
@@ -6,6 +6,7 @@ let
     mkIf
     toHexString
     versionAtLeast
+    versionOlder
   ;
 
   inherit (config.Tow-Boot)
@@ -145,7 +146,7 @@ in
     (mkIf withLogo (helpers: with helpers; {
       VIDEO_LOGO = mkIf (versionAtLeast config.Tow-Boot.uBootVersion "2022.04") yes;
       CMD_BMP = yes;
-      SPLASHIMAGE_GUARD = yes;
+      SPLASHIMAGE_GUARD = mkIf (versionOlder config.Tow-Boot.uBootVersion "2023.01") yes;
       SPLASH_SCREEN = yes;
       SPLASH_SCREEN_ALIGN = yes;
       VIDEO_BMP_GZIP = yes;

--- a/modules/tow-boot/options.nix
+++ b/modules/tow-boot/options.nix
@@ -104,6 +104,12 @@ in
         type = with types; nullOr str;
         default = null;
       };
+
+      VIDEO_LOGO_MAX_SIZE = mkOption {
+        type = types.str;
+        default = toString (1920*1080*4);
+        internal = true;
+      };
     };
   };
 }

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -59,6 +59,10 @@ in
           "2022.01" = "sha256-gbRUMifbIowD+KG/XdvIE7C7j2VVzkYGTvchpvxoBBM=";
           "2022.04" = "sha256-aOBlQTkmd44nbsOr0ouzL6gquqSmiY1XDB9I+9sIvNA=";
           "2022.07" = "sha256-krCOtJwk2hTBrb9wpxro83zFPutCMOhZrYtnM9E9z14=";
+          "2022.10" = "sha256-ULRIKlBbwoG6hHDDmaPCbhReKbI1ALw1xQ3r1/pGvfg=";
+          "2023.01" = "sha256-aUI7rTgPiaCRZjbonm3L0uRRLVhDCNki0QOdHkMxlQ8=";
+          "2023.04" = "sha256-4xyskVRf9BtxzsXYwir9aVZFzW4qRCzNrKzWBTQGk0E=";
+          "2023.07" = "sha256-EukhtGaucxzbw1Xmgyt/IryQsBrs7vmIb5iquns5QwA=";
         };
         Tow-Boot = {
           "2022.07" = "sha256-AMnY5gzvN66vVJAIlJNzEreNxi0NeVStD55F8u+sm1Q=";

--- a/modules/u-boot.nix
+++ b/modules/u-boot.nix
@@ -35,5 +35,13 @@ mkIf config.Tow-Boot.buildUBoot
     # sunxi: Use mmc_get_env_dev only if relevant
     (tbPatch "eb193c32c471a829a0b81c6a94f9bb9b9e392fb3" "sha256-K7p8gDJwoaTMdVgvfXC2l/u6dxnIoEBrD+yoXpvY3EY=")
   ]
+  ++ optionals (uBootVersion == "2023.07") [
+    # New regression in 2023.07, will be fixed by 2023.10
+    # common: Kconfig: Fix CMD_BMP/BMP dependency
+    (fetchpatch {
+      url = "https://patchwork.ozlabs.org/project/uboot/patch/20230709231810.633044-1-samuel@dionne-riel.com/raw/";
+      sha256 = "sha256-hBv2BeLjyUr4ydTieNv8AZ0FGXqwKHo+2+GyLGgodUQ=";
+    })
+  ]
   ;
 }

--- a/modules/u-boot.nix
+++ b/modules/u-boot.nix
@@ -3,9 +3,16 @@
 let
   inherit (lib)
     mkIf
+    optionals
+    versionOlder
+    versionAtLeast
   ;
   inherit (pkgs)
     fetchpatch
+  ;
+
+  inherit (config.Tow-Boot)
+    uBootVersion
   ;
 
   tbPatch =
@@ -19,8 +26,14 @@ in
 mkIf config.Tow-Boot.buildUBoot  
 {
   # Fixes for stock U-Boot
-  Tow-Boot.patches = [
+  Tow-Boot.patches = []
+  ++ optionals (versionOlder uBootVersion "2023.01") [
     # sunxi: Use mmc_get_env_dev only if relevant
     (tbPatch "e1d686d0591e8fa95d5218d965ec3b0aa83c5d27" "sha256-u3LVyKJvx5QDMJig+blFF1nGnSbVdCEI7zDx8HvHBfA=")
-  ];
+  ]
+  ++ optionals (versionAtLeast uBootVersion "2023.01") [
+    # sunxi: Use mmc_get_env_dev only if relevant
+    (tbPatch "eb193c32c471a829a0b81c6a94f9bb9b9e392fb3" "sha256-K7p8gDJwoaTMdVgvfXC2l/u6dxnIoEBrD+yoXpvY3EY=")
+  ]
+  ;
 }

--- a/support/check-all-stock-uboot.nix
+++ b/support/check-all-stock-uboot.nix
@@ -1,9 +1,12 @@
 # This is used to check all stock U-Boot versions don't have unexpected default options regressions.
 # E.g. configuration options not properly gated behind a version.
 # Again, not a guarantee of usefulness, used to keep us more honest.
+{ device ? "uBoot-sandbox"
+}:
+
 let
   eval = configuration:
-    (import ../. { inherit configuration; }).uBoot-sandbox
+    (import ../. { inherit configuration; })."${device}"
   ;
 
   # Used to extract known versions.


### PR DESCRIPTION
**This does not update Tow-Boot.**

* * *

This adds the missing U-Boot versions up to 2023.07 to the knowledge for stock U-Boot.

This also fixes some missing version-gating of configs.

And finally handles some required patching.

* * *

### What was done

 - Built U-Boot sandbox with `nix-build support/check-all-stock-uboot.nix`
 - Built Pinebook A64 for 2022.07..2023.07
 - Ran 2023.07 on the Pinebook A64

For our purpose here, this is sufficient.

Reminder that this is supposed to serve as a way to verify regressions with stock U-Boot with a limited scope. And generally helps us confirm when things break if it's Tow-Boot or U-Boot. It is a development tool and not a product for end-users.