### PR TITLE
nixpkgs: Update to July 8th nixos-unstable channel

### DIFF
--- a/boards/olimex-teresI/default.nix
+++ b/boards/olimex-teresI/default.nix
@@ -12,10 +12,5 @@
 
   Tow-Boot = {
     defconfig = "teres_i_defconfig";
-    # Not available in crust
-    # https://github.com/crust-firmware/crust/issues/195
-    builder.additionalArguments = {
-      SCP = null;
-    };
   };
 }

--- a/boards/raspberryPi-aarch64/default.nix
+++ b/boards/raspberryPi-aarch64/default.nix
@@ -72,9 +72,9 @@ in
     ];
     outputs.firmware = lib.mkIf (config.device.identifier == "raspberryPi-aarch64") (
       pkgs.callPackage (
-        { runCommandNoCC }:
+        { runCommand }:
 
-        runCommandNoCC "tow-boot-${config.device.identifier}" {
+        runCommand "tow-boot-${config.device.identifier}" {
           inherit (raspberryPi-3.config.Tow-Boot.outputs.firmware)
             version
           ;

--- a/doc/_support/devices/default.nix
+++ b/doc/_support/devices/default.nix
@@ -1,6 +1,6 @@
 { pkgs
 , glibcLocales
-, runCommandNoCC
+, runCommand
 , symlinkJoin
 , ruby
 }:
@@ -15,7 +15,7 @@ let
   };
 in
 
-runCommandNoCC "Tow-Boot-docs-devices" {
+runCommand "Tow-Boot-docs-devices" {
   nativeBuildInputs = [
     ruby
     glibcLocales

--- a/doc/_support/styles/default.nix
+++ b/doc/_support/styles/default.nix
@@ -1,5 +1,5 @@
 { stdenv
-, runCommandNoCCLocal
+, runCommandLocal
 , writeShellScriptBin
 , nodePackages
 }:
@@ -40,7 +40,7 @@ let
     rm -rf $in.tmp
   '';
 
-  stylesAssets = runCommandNoCCLocal "tow-boot-styles-assets" {
+  stylesAssets = runCommandLocal "tow-boot-styles-assets" {
     nativeBuildInputs = [
       embedSVG
     ];

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -6,9 +6,9 @@ let
   output = 
     pkgs.callPackage (
 
-    { runCommandNoCC, cmark-gfm, ruby }:
+    { runCommand, cmark-gfm, ruby }:
 
-    runCommandNoCC "Tow-Boot-documentation" {
+    runCommand "Tow-Boot-documentation" {
       src = (builtins.fetchGit ../.) + "/doc";
       nativeBuildInputs = [
         cmark-gfm

--- a/modules/build.nix
+++ b/modules/build.nix
@@ -67,8 +67,8 @@ in
   config = {
     build = {
       archive = pkgs.callPackage (
-        { runCommandNoCC, Tow-Boot, name }:
-          runCommandNoCC "${name}.tar.xz" {
+        { runCommand, Tow-Boot, name }:
+          runCommand "${name}.tar.xz" {
             dir = name;
           } ''
             PS4=" $ "
@@ -85,11 +85,11 @@ in
       };
 
       default = pkgs.callPackage (
-        { lib, runCommandNoCC, firmware, firmwareMMCBoot, firmwareSPI, sharedDiskImage, mmcBootInstallerImage, spiInstallerImage }:
+        { lib, runCommand, firmware, firmwareMMCBoot, firmwareSPI, sharedDiskImage, mmcBootInstallerImage, spiInstallerImage }:
         let
           inherit (lib) optionalString;
         in
-        runCommandNoCC "Tow-Boot.${config.device.identifier}.${config.build.default.version}" {
+        runCommand "Tow-Boot.${config.device.identifier}.${config.build.default.version}" {
           inherit (firmware) version;
         } ''
           mkdir -p $out/{binaries,config}

--- a/modules/tow-boot/builder.nix
+++ b/modules/tow-boot/builder.nix
@@ -258,7 +258,7 @@ in
               # To produce the bitmap image:
               #     convert input.png -depth 8 -colors 256 -compress none output.bmp
               # This tiny build produces the `.gz` file that will actually be used.
-              compressedLogo = pkgs.buildPackages.runCommandNoCC "uboot-logo" {} ''
+              compressedLogo = pkgs.buildPackages.runCommand "uboot-logo" {} ''
                 mkdir -p $out
                 cp ${../../assets/splash.bmp} $out/logo.bmp
                 (cd $out; gzip -n -9 -k logo.bmp)

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,6 +1,6 @@
 let
-  rev = "1905f5f2e55e0db0bb6244cfe62cb6c0dbda391d";
-  sha256 = "148f79hhya66qj8v5gn7bs6zrfjy1nbvdciyxdm4yd5p8r6ayzv6";
+  rev = "f292b4964cb71f9dfbbd30dc9f511d6165cd109b";
+  sha256 = "sha256:01yzrkrb60dd2y2y3fh4939z374hf5pa92q8axfcygqlnbk3jpb4";
   tarball = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
     inherit sha256;

--- a/release.nix
+++ b/release.nix
@@ -19,7 +19,7 @@ let
 
   release-tools = import ./support/nix/release-tools.nix { inherit pkgs; };
 in
-  pkgs.runCommandNoCC "Tow-Boot.release.${version}" {
+  pkgs.runCommand "Tow-Boot.release.${version}" {
     inherit version;
   } ''
     mkdir -p $out

--- a/support/image-builder/disk-image/partitioning-scheme/gpt/builder.nix
+++ b/support/image-builder/disk-image/partitioning-scheme/gpt/builder.nix
@@ -3,7 +3,7 @@
 , fetchpatch
 , gptfdisk
 , buildPackages
-#, utillinux
+, utillinux
 , config
 }:
 
@@ -22,19 +22,6 @@ let
   inherit (config.gpt)
     hybridMBR
   ;
-
-  # Until we get 2.37 in Nixpkgs
-  patched-utillinux = buildPackages.utillinux.overrideAttrs({patches ? [], ...}: {
-    patches = patches ++ [
-      (fetchpatch {
-        # Same as the following commit, but for 2.36
-        # https://github.com/karelzak/util-linux/commit/60f2d1f0a7902b351195418f2116d7ea39a35369
-        url = "https://raw.githubusercontent.com/Tow-Boot/Tow-Boot/4a39ca8f6706d8262f0317f815cbcec587e1e0fa/support/image-builder/patches/0001-2.36-libfdisk-Include-table-length-in-first-lba-chec.patch";
-        sha256 = "1j4yndlblak4gq09hqmy6fxhh3b7qky102cl6ynjwrfz16ymqk67";
-      })
-    ];
-  });
-
 in
 stdenvNoCC.mkDerivation rec {
   inherit (config)
@@ -52,7 +39,7 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [
     gptfdisk
-    patched-utillinux
+    utillinux
   ];
 
   buildCommand = let

--- a/support/image-builder/disk-image/partitioning-scheme/mbr/builder.nix
+++ b/support/image-builder/disk-image/partitioning-scheme/mbr/builder.nix
@@ -2,7 +2,7 @@
 , lib
 , fetchpatch
 , buildPackages
-#, utillinux
+, utillinux
 , config
 }:
 
@@ -18,19 +18,6 @@ let
   inherit (config)
     partitions
   ;
-
-  # Until we get 2.37 in Nixpkgs
-  patched-utillinux = buildPackages.utillinux.overrideAttrs({patches ? [], ...}: {
-    patches = patches ++ [
-      (fetchpatch {
-        # Same as the following commit, but for 2.36
-        # https://github.com/karelzak/util-linux/commit/60f2d1f0a7902b351195418f2116d7ea39a35369
-        url = "https://raw.githubusercontent.com/Tow-Boot/Tow-Boot/4a39ca8f6706d8262f0317f815cbcec587e1e0fa/support/image-builder/patches/0001-2.36-libfdisk-Include-table-length-in-first-lba-chec.patch";
-        sha256 = "1j4yndlblak4gq09hqmy6fxhh3b7qky102cl6ynjwrfz16ymqk67";
-      })
-    ];
-  });
-
 in
 stdenvNoCC.mkDerivation rec {
   inherit (config)
@@ -46,7 +33,7 @@ stdenvNoCC.mkDerivation rec {
   img = placeholder "out";
 
   nativeBuildInputs = [
-    patched-utillinux
+    utillinux
   ];
 
   buildCommand = let

--- a/support/nix/eval-kconfig.nix
+++ b/support/nix/eval-kconfig.nix
@@ -59,7 +59,7 @@
             ${lib.concatMapStringsSep "\n" ({key, item}:
             let
               line = lib.escapeShellArg (mkConfigLine key item);
-              escapedLinePattern = lib.replaceChars ["[" "]" ''\''] [ ''\['' ''\]'' ''\\''] line;
+              escapedLinePattern = lib.replaceStrings ["[" "]" ''\''] [ ''\['' ''\]'' ''\\''] line;
               lineNotSet = "# CONFIG_${key} is not set";
               linePattern = "^CONFIG_${key}=";
               presencePattern = "CONFIG_${key}[ =]";

--- a/support/nix/eval-with-configuration.nix
+++ b/support/nix/eval-with-configuration.nix
@@ -82,7 +82,7 @@ in
 eval.config.build.default.overrideAttrs({ passthru ? {}, ... }: {
   passthru = passthru // {
     inherit eval;
-    inherit (eval) config pkgs;
+    inherit (eval) config pkgs options;
     inherit (eval.config) build;
   };
 })

--- a/support/overlay/arm-trusted-firmware/default.nix
+++ b/support/overlay/arm-trusted-firmware/default.nix
@@ -70,12 +70,11 @@ in {
   armTrustedFirmwareTools = buildArmTrustedFirmware rec {
     extraMakeFlags = [
       "HOSTCC=${stdenv.cc.targetPrefix}gcc"
-      "fiptool" "certtool" "sptool"
+      "fiptool" "certtool"
     ];
     filesToInstall = [
       "tools/fiptool/fiptool"
       "tools/cert_create/cert_create"
-      "tools/sptool/sptool"
     ];
     postInstall = ''
       mkdir -p "$out/bin"

--- a/support/overlay/arm-trusted-firmware/default.nix
+++ b/support/overlay/arm-trusted-firmware/default.nix
@@ -15,7 +15,7 @@ let
             , platform ? null
             , extraMakeFlags ? []
             , extraMeta ? {}
-            , version ? "2.6"
+            , version ? "2.9"
             , ... } @ args:
            stdenv.mkDerivation ({
 
@@ -26,7 +26,7 @@ let
       owner = "ARM-software";
       repo = "arm-trusted-firmware";
       rev = "v${version}";
-      sha256 = "sha256-qT9DdTvMcUrvRzgmVf2qmKB+Rb1WOB4p1rM+fsewGcg=";
+      sha256 = "sha256-F7RNYNLh0ORzl5PmzRX9wGK8dZgUQVLKQg1M9oNd0pk=";
     };
 
     depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/support/overlay/crust-firmware/default.nix
+++ b/support/overlay/crust-firmware/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "crust-firmware";
-  version = "0.5";
+  version = "untagged-2023-02-28";
 
   src = fetchFromGitHub {
     owner = "crust-firmware";
     repo = "crust";
-    rev = "v${version}";
-    sha256 = "sha256-f2+5y5RIFqLWLokD4P8r/2F77kxYmutH47GO5yJc63U=";
+    rev = "c308a504853e7fdb47169796c9a832796410ece8";
+    sha256 = "sha256-AobVD3Jo/6s0cExHXpYYAqZv/gCplxLlDYVscSCIS6M=";
   };
 
   depsBuildBuild = [

--- a/support/overlay/overlay.nix
+++ b/support/overlay/overlay.nix
@@ -74,7 +74,7 @@ in
 
     meson64-tools = callPackage ./meson64-tools { };
 
-    mkScript = file: final.runCommandNoCC "out.scr" {
+    mkScript = file: final.runCommand "out.scr" {
       nativeBuildInputs = [
         final.buildPackages.ubootTools
       ];


### PR DESCRIPTION
This is an update to the "toolchain" we're relying on. Namely the compilers and such.

With this, I also updated some of the misc. packages, namely crust and TF-A.

This update should be mostly a no-op for Tow-Boot changes, though it may change some board's behaviour depending on TF-A or crust.

There is also the rare chance that compiler update from the updating tooling could surface extremely-unlikely weirdness in the compiled output, but given it builds I think it's unlikely.

This was superficially tested along with #252.

This is what supersedes #250.