### PR TITLE
WIP: Update base to U-Boot 2023.07

### DIFF
--- a/boards/uBoot-sandbox/default.nix
+++ b/boards/uBoot-sandbox/default.nix
@@ -24,6 +24,9 @@
         VIDEO_SANDBOX_SDL = yes;
         SANDBOX_RAM_SIZE_MB = freeform "512";
       })
+      (helpers: with helpers; {
+        BOOTSTD = lib.mkForce yes;
+      })
     ];
     builder = {
       buildInputs = [

--- a/embedded-linux-os/devices/pine64-pinephoneA64/kernel/default.nix
+++ b/embedded-linux-os/devices/pine64-pinephoneA64/kernel/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "5.15.0";
 
   src = fetchFromGitHub {
-    owner = "megous";
+    owner = "samueldr"; # Originally megous
     repo = "linux";
     rev = "3cc817fa5bfb1f9c6c1630707cd7aa6d00f4efe3";
     sha256 = "0hwi3z7sppw9pnxjjy0skrrgjicv652k6mlzz1q3nkimbfdgm6cs";

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -16,6 +16,7 @@ let
     variant
   ;
   cfg = config.hardware.socs;
+  withSPI = config.hardware.SPISize != null;
 
   firmwareMaxSize = 4 * 1024 * 1024; # MiB in bytes
   partitionOffset = 64; # in sectors
@@ -46,7 +47,7 @@ in
     (mkIf cfg.rockchip-rk3399.enable {
       system.system = "aarch64-linux";
       Tow-Boot = {
-        config = [
+        config = mkIf withSPI [
           (helpers: with helpers; {
             # SPI boot Support
             MTD = yes;

--- a/modules/tow-boot/builder.nix
+++ b/modules/tow-boot/builder.nix
@@ -122,6 +122,11 @@ in
             patchShebangs tools
             patchShebangs arch/arm/mach-rockchip
           '' +
+          ''
+            # Drop that from the exposed version, always.
+            # We use releases, any extra qualifier is owned by us.
+            sed -i -e 's/^EXTRAVERSION =.*/EXTRAVERSION =/' Makefile
+          '' +
             # FIXME: review how we patch this out... (I don't like it)
           ''
             echo ':: Patching baud rate'

--- a/modules/tow-boot/builder.nix
+++ b/modules/tow-boot/builder.nix
@@ -166,6 +166,7 @@ in
             buildPackages.libuuid # For tools/mkeficapsule
             (buildPackages.python3.withPackages (p: [
               p.libfdt
+              p.pyelftools
               p.setuptools # for pkg_resources
             ]))
           ] ++ nativeBuildInputs;

--- a/modules/tow-boot/config.nix
+++ b/modules/tow-boot/config.nix
@@ -155,6 +155,7 @@ in
       BMP_32BPP = yes;
       SPLASH_SOURCE = no;
       VIDEO_LOGO_MAX_SIZE = mkIf (versionAtLeast config.Tow-Boot.uBootVersion "2023.01") (freeform config.Tow-Boot.VIDEO_LOGO_MAX_SIZE);
+      HIDE_LOGO_VERSION = mkIf (versionAtLeast config.Tow-Boot.uBootVersion "2023.01") yes;
     }))
   ];
 }

--- a/modules/tow-boot/config.nix
+++ b/modules/tow-boot/config.nix
@@ -12,11 +12,12 @@ let
   inherit (config.Tow-Boot)
     variant
     releaseNumber
+    releaseRC
     releaseIdentifier
     withLogo
   ;
 
-  towBootIdentifier = "${releaseNumber}${releaseIdentifier}";
+  towBootIdentifier = "${releaseNumber}${releaseRC}${releaseIdentifier}";
 
   # Not actually configurable. This is a constant in Tow-Boot.
   # Changing this will require handling the migration to a larger size.

--- a/modules/tow-boot/config.nix
+++ b/modules/tow-boot/config.nix
@@ -140,6 +140,18 @@ in
       ENV_OFFSET =  freeform "0x${toHexString envSPIOffset}";
     }))
 
+    # Partial `bootstd` migration temporary measures
+    (helpers: with helpers; {
+      # For now, it's outright disabled, we will need to re-evaluate our
+      # infra to work with bootstd, but only after a larger proportion of
+      # the devices default to `bootstd`.
+      BOOTSTD = no;
+      BOOTSTD_DEFAULTS = no;
+      DISTRO_DEFAULTS = yes;
+      USE_BOOTCOMMAND = yes;
+      BOOTCOMMAND = freeform ''"run distro_bootcmd"'';
+    })
+
     # Logo handling
     # -------------
 

--- a/modules/tow-boot/identity.nix
+++ b/modules/tow-boot/identity.nix
@@ -1,6 +1,7 @@
 {
   Tow-Boot = {
     releaseNumber = "007";
+    releaseRC = "-rc1";
     releaseIdentifier = "-pre";
   };
 }

--- a/modules/tow-boot/options.nix
+++ b/modules/tow-boot/options.nix
@@ -15,6 +15,13 @@ in
           Version of the underlying U-Boot version.
         '';
       };
+      tag = mkOption {
+        type = types.str;
+        internal = true;
+        description = ''
+          Tag used for the Tow-Boot source code.
+        '';
+      };
       src = mkOption {
         type = with types; oneOf [path package];
         description = ''
@@ -74,6 +81,15 @@ in
         type = types.str;
         description = ''
           Must be `-pre` for builds other than ones coming from the clean tagged version commit.
+        '';
+      };
+      releaseRC = mkOption {
+        type = types.str;
+        default = "";
+        internal = true;
+        example = "-rc1";
+        description = ''
+          RC part of the tag, for pre-release management.
         '';
       };
 

--- a/modules/tow-boot/options.nix
+++ b/modules/tow-boot/options.nix
@@ -107,7 +107,7 @@ in
 
       VIDEO_LOGO_MAX_SIZE = mkOption {
         type = types.str;
-        default = toString (1920*1080*4);
+        default = ''0x${lib.toHexString (1920*1080*4)}'';
         internal = true;
       };
     };

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -48,7 +48,7 @@ in
   };
   config = {
     Tow-Boot = {
-      uBootVersion = mkDefault "2022.07";
+      uBootVersion = mkDefault "2023.07";
 
       knownHashes = {
         U-Boot = {

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -8,7 +8,13 @@ let
     optionals
     types
   ;
-  inherit (config.Tow-Boot) uBootVersion variant;
+  inherit (config.Tow-Boot)
+    releaseRC
+    releaseNumber
+    tag
+    uBootVersion
+    variant
+  ;
 in
 
 {
@@ -49,6 +55,7 @@ in
   config = {
     Tow-Boot = {
       uBootVersion = mkDefault "2023.07";
+      tag = mkDefault "tb-${uBootVersion}-${releaseNumber}${releaseRC}";
 
       knownHashes = {
         U-Boot = {
@@ -65,7 +72,7 @@ in
           "2023.07" = "sha256-EukhtGaucxzbw1Xmgyt/IryQsBrs7vmIb5iquns5QwA=";
         };
         Tow-Boot = {
-          "2022.07" = "sha256-AMnY5gzvN66vVJAIlJNzEreNxi0NeVStD55F8u+sm1Q=";
+          "tb-2023.07-007-rc1" = "sha256-vAB7MHn5VZEo3fPR7zWADpUMJ14Una90JrXRSPI9T9U=";
         };
       };
 
@@ -84,11 +91,11 @@ in
         mkDefault (pkgs.fetchFromGitHub {
           repo = "U-Boot";
           owner = "Tow-Boot";
-          rev = "tow-boot/${uBootVersion}/_all";
+          rev = "${tag}";
           sha256 =
-            if knownHashes ? ${uBootVersion}
-            then knownHashes.${uBootVersion}
-            else builtins.throw "No known hashes for Tow-Boot-flavoured U-Boot matching U-Boot version ${uBootVersion}"
+            if knownHashes ? ${tag}
+            then knownHashes.${tag}
+            else builtins.throw "No known hashes for Tow-Boot-flavoured U-Boot matching tag ${tag}"
           ;
         })
       ;

--- a/support/release.sh
+++ b/support/release.sh
@@ -18,6 +18,11 @@ sed -i -e \
 	's/releaseIdentifier = "-pre";/releaseIdentifier = "";/' \
 	modules/tow-boot/identity.nix
 
+# Remove any `-rc` suffix
+sed -i -e \
+	's/releaseRC = .*/releaseRC = "";/' \
+	modules/tow-boot/identity.nix
+
 # Commit and tag the version
 version="$(nix-instantiate --eval -E '(import ./release.nix {}).version' | sed -e 's/"//g')"
 git add modules/tow-boot/identity.nix


### PR DESCRIPTION
Feature branches here:

 - https://github.com/Tow-Boot/U-Boot/branches/all?query=tow-boot%2F2023.07%2F

### TODO

We'll need to tag the current state of the Tow-Boot fork, whether or not it is what is released as `2023.07`.

 - [x] Tag `2023.07-007-rc1` in the U-Boot repo with the accepted state
 - [x] Change impl. to work with that tag while in rc


### Known issues

<details><summary>"Resolved" rockchip issue</summary>

#### Rockchip

Rockchip moved to "standard[sic] boot" breaking the assumptions of the boot menu builder.

AFAIK this is the only actual real-world target/family that has moved to it.

A solution will need to be found, I haven't spent much time thinking about it yet.

The first thought I had is that *since anyway* we have to mess with distroboot things for most targets, we might benefit from making a "unified" distroboot env within our fork, instead of relying on the board-specific distroboot builders. And on top of that, making the *order* they are tried a `CONFIG_TOW_BOOT_DISTROBOOT_TARGETS` option, meaning that the boot order and targets can be handled through direct configuration rather than messy patches and `#ifdef`s.

That solution would be a stop-gap until the new boot methods are more universally enabled (maybe we can help down the line) and we would instead use the data from bootstd directly without going through cli commands when building the UI.

</details>

* * *

### Changelog

 - "Resolved" the Rockchip conundrum https://github.com/Tow-Boot/U-Boot/compare/d705eb1a60dbc6d507974afbf1c26663c321077c...61f7ac4831c93f74f2f542966d072f4aa62fc5cc