### PR TITLE
Add support for Libre Computer ALL-H3-CC H5

### DIFF
--- a/boards/libreComputer-allH3CcH5/default.nix
+++ b/boards/libreComputer-allH3CcH5/default.nix
@@ -1,0 +1,16 @@
+{
+  device = {
+    manufacturer = "Libre Computer";
+    name = "ALL-H3-CC H5";
+    identifier = "allH3CcH5";
+    productPageURL = "https://libre.computer/products/all-h3-cc/";
+  };
+
+  hardware = {
+    soc = "allwinner-h5";
+  };
+
+  Tow-Boot = {
+    defconfig = "libretech_all_h3_cc_h5_defconfig";
+  };
+}


### PR DESCRIPTION
Support was tested only with [this tree](https://github.com/samueldr/Tow-Boot/tree/feature/tow-boot-2023.07).
At least Libre Computer [own image](https://distro.libre.computer/ci/ubuntu/23.04/ubuntu-23.04-preinstalled-desktop-arm64%2Ball-h3-cc-h5.img.xz) boot fine.