### PR TITLE
Add support for FriendlyELEC NanoPi M1

### DIFF
--- a/boards/friendlyElec-nanoPiM1/default.nix
+++ b/boards/friendlyElec-nanoPiM1/default.nix
@@ -1,0 +1,17 @@
+{
+  device = {
+    manufacturer = "FriendlyELEC";
+    name = "NanoPi M1";
+    identifier = "friendlyElec-nanoPiM1";
+    productPageURL = "https://wiki.friendlyelec.com/wiki/index.php/NanoPi_M1";
+  };
+
+  hardware = {
+    soc = "allwinner-h3";
+    allwinner.crust.defconfig = "nanopi_m1_defconfig";
+  };
+
+  Tow-Boot = {
+    defconfig = "nanopi_m1_defconfig";
+  };
+}


### PR DESCRIPTION
Support was tested only with [this tree](https://github.com/samueldr/Tow-Boot/tree/feature/tow-boot-2023.07).

At least Debian 12 armhf boot fine, but in my case - only in headless mode, which could be related to my display (Dell UP3017) resolution 2560x1600. However, while I getting black screen when kernel switch from framebuffer, video output before this moment (including video output in Tow-Boot and GRUB2) works without issues. Another observation is that USB support is a bit flaky - Tow-Boot goes into boot loop if Belkin USB-C 3.1 Express Dock HD or even Satechi Type-C Card Reader (expose two block devices) is connected, but this isn't likely to cause any issues in real-world scenarios for this board (signage, thin client, print server, pihole, etc.)

Anyway, with 2022.07 test branches situation was even worse (I wasn't able to even get to Tow-Boot's menu as I remember) so we still have a nice progress here.