### PR TITLE
odroid-HC4: Init board

### DIFF
--- a/boards/odroid-HC4/default.nix
+++ b/boards/odroid-HC4/default.nix
@@ -1,0 +1,29 @@
+{ lib, pkgs, ... }:
+
+{
+  device = {
+    manufacturer = "Hardkernel";
+    name = "ODROID-HC4";
+    identifier = "odroid-HC4";
+    productPageURL = "https://www.hardkernel.com/shop/odroid-hc4/";
+  };
+
+  hardware = {
+    soc = "amlogic-s905x3";
+    SPISize = 16 * 1024 * 1024; # 16 MiB
+  };
+
+  Tow-Boot = {
+    defconfig = "odroid-hc4_defconfig";
+    config = [
+      (helpers: with helpers; {
+        USE_PREBOOT = yes;
+        # 'run boot_pci_enum' is required before 'usb start' to have working USB
+        PREBOOT = freeform ''"run boot_pci_enum; usb start ; usb info"'';
+      })
+    ];
+    builder.additionalArguments = {
+      FIPDIR = "${pkgs.Tow-Boot.amlogicFirmware}/odroid-hc4";
+    };
+  };
+}


### PR DESCRIPTION
The Hardkernel Odroid HC4 is similar to the Odroid C4.

There are however two strange behaviors:

1. Without calling `run boot_pci_enum` before `usb start`, the USB won't work.
2. `spi.installer.img` is unable to access the SPI. This bug is explained here: https://github.com/armbian/build/blob/4db330178fbe93b52e7987e8ce69ab9eaddd5377/patch/u-boot/v2023.01/board_odroidhc4/board.odroidhc4.hc4_sd_defconfig.for.writing.to.mtd.patch

I am unable to figure out how to configure Two-Boot to override `CONFIG_DEFAULT_DEVICE_TREE="meson-sm1-odroid-c4"` only for `spi.installer.img` (to circumvent the second strange behavior).