### PR TITLE
Add support for FriendlyELEC NanoPi K1 Plus

### DIFF
--- a/boards/friendlyElec-nanoPiK1Plus/0001-nanopi-k1-plus-board-enablement.patch
+++ b/boards/friendlyElec-nanoPiK1Plus/0001-nanopi-k1-plus-board-enablement.patch
@@ -1,0 +1,172 @@
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index b6eebe8..a6eb75b 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -371,6 +371,7 @@ dtb-$(CONFIG_MACH_SUN50I_H5) += \
+ 	sun50i-h5-orangepi-zero-plus.dtb \
+ 	sun50i-h5-nanopi-m1-plus2.dts \
+ 	sun50i-h5-orangepi-pc2.dtb \
++	sun50i-h5-nanopi-k1-plus.dtb \
+ 	sun50i-h5-orangepi-prime.dtb \
+ 	sun50i-h5-orangepi-zero-plus2.dtb
+ dtb-$(CONFIG_MACH_SUN50I) += \
+diff --git a/arch/arm/dts/sun50i-h5-nanopi-k1-plus.dts b/arch/arm/dts/sun50i-h5-nanopi-k1-plus.dts
+new file mode 100644
+index 0000000..c08af78
+--- /dev/null
++++ b/arch/arm/dts/sun50i-h5-nanopi-k1-plus.dts
+@@ -0,0 +1,125 @@
++/*
++ * Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
++ * Copyright (C) 2017 Jagan Teki <jteki@openedev.com>
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This library is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This library is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++/dts-v1/;
++
++#include "sun50i-h5.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++
++/ {
++	model = "FriendlyARM NanoPi K1 plus";
++	compatible = "friendlyarm,nanopi-neo2", "allwinner,sun50i-h5";
++
++	aliases {
++		serial0 = &uart0;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	reg_vcc3v3: vcc3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++	};
++};
++
++&mmc0 {
++	compatible = "allwinner,sun50i-h5-mmc",
++		     "allwinner,sun50i-a64-mmc",
++		     "allwinner,sun5i-a13-mmc";
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc0_pins>;
++	vmmc-supply = <&reg_vcc3v3>;
++	bus-width = <4>;
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
++	status = "okay";
++};
++
++&mmc2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc2_8bit_pins>;
++	vmmc-supply = <&reg_vcc3v3>;
++	bus-width = <8>;
++	non-removable;
++	cap-mmc-hw-reset;
++	status = "okay";
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_pa_pins>;
++	status = "okay";
++};
++
++&usbphy {
++	status = "okay";
++};
++
++&ohci1 {
++	status = "okay";
++};
++
++&ehci1 {
++	status = "okay";
++};
++
++&ohci2 {
++	status = "okay";
++};
++
++&ehci2 {
++	status = "okay";
++};
++
++&ohci3 {
++	status = "okay";
++};
++
++&ehci3 {
++	status = "okay";
++};
++
+diff --git a/configs/nanopi_k1_plus_defconfig b/configs/nanopi_k1_plus_defconfig
+new file mode 100644
+index 0000000..670c3c7
+--- /dev/null
++++ b/configs/nanopi_k1_plus_defconfig
+@@ -0,0 +1,23 @@
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_SYS_TEXT_BASE=0x4a000000
++CONFIG_SPL_SPI_FLASH_SUPPORT=y
++CONFIG_MACH_SUN50I_H5=y
++CONFIG_DRAM_CLK=504
++CONFIG_DRAM_ZQ=3881977
++CONFIG_MACPWR="PD6"
++CONFIG_DRAM_ODT_EN=y
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
++CONFIG_DEFAULT_DEVICE_TREE="sun50i-h5-nanopi-k1-plus"
++# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_SPL=y
++# CONFIG_CMD_IMLS is not set
++# CONFIG_CMD_FLASH is not set
++# CONFIG_CMD_FPGA is not set
++# CONFIG_SPL_DOS_PARTITION is not set
++# CONFIG_SPL_ISO_PARTITION is not set
++# CONFIG_SPL_EFI_PARTITION is not set
++CONFIG_SPL_SPI_SUNXI=y
++CONFIG_SUN8I_EMAC=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_SYS_USB_EVENT_POLL_VIA_INT_QUEUE=y

--- a/boards/friendlyElec-nanoPiK1Plus/default.nix
+++ b/boards/friendlyElec-nanoPiK1Plus/default.nix
@@ -15,5 +15,8 @@
     patches = [
       ./0001-nanopi-k1-plus-board-enablement.patch
     ];
+    builder.additionalArguments = {
+      SCP = "/dev/null";
+    };
   };
 }

--- a/boards/friendlyElec-nanoPiK1Plus/default.nix
+++ b/boards/friendlyElec-nanoPiK1Plus/default.nix
@@ -1,0 +1,19 @@
+{
+  device = {
+    manufacturer = "FriendlyELEC";
+    name = "NanoPi K1 Plus";
+    identifier = "friendlyElec-nanoPiK1Plus";
+    productPageURL = "https://wiki.friendlyelec.com/wiki/index.php/NanoPi_K1_Plus";
+  };
+
+  hardware = {
+    soc = "allwinner-h5";
+  };
+
+  Tow-Boot = {
+    defconfig = "nanopi_k1_plus_defconfig";
+    patches = [
+      ./0001-nanopi-k1-plus-board-enablement.patch
+    ];
+  };
+}


### PR DESCRIPTION
Hello!

This is work in progress. I tried to add NanoPi K1 Plus board support, but build fail for some reason:

```
***
*** Can't find default configuration "./configs/nanopi_k1_plus_defconfig"!
***
make: *** [3rdparty/kconfig/Makefile:49: nanopi_k1_plus_defconfig] Error 1
error: builder for '/nix/store/qanzsx3bn36hdwahlw6rc21g9z5gwzyb-crust-firmware-untagged-2023-02-28.drv' failed with exit code 2
error: 1 dependencies of derivation '/nix/store/3r51blna4kv3z1a797ilb9h5il521r7j-Tow-Boot-nanopi_k1_plus_defconfig-noenv-aarch64-unknown-linux-gnu-2023.07-007-pre.drv' failed to build
error: 1 dependencies of derivation '/nix/store/5l90rm73n1sbxr4rn1njkhqvqiapysjq-Tow-Boot.friendlyElec-nanoPiK1Plus.2023.07-007-pre.drv' failed to build

```