### PR TITLE
Add support level to device descriptions

### DIFF
--- a/boards/friendlyElec-nanoPiM1/default.nix
+++ b/boards/friendlyElec-nanoPiM1/default.nix
@@ -4,6 +4,7 @@
     name = "NanoPi M1";
     identifier = "friendlyElec-nanoPiM1";
     productPageURL = "https://wiki.friendlyelec.com/wiki/index.php/NanoPi_M1";
+    supportLevel = "best-effort";
   };
 
   hardware = {

--- a/boards/libreComputer-allH3CcH5/default.nix
+++ b/boards/libreComputer-allH3CcH5/default.nix
@@ -4,6 +4,7 @@
     name = "ALL-H3-CC H5";
     identifier = "allH3CcH5";
     productPageURL = "https://libre.computer/products/all-h3-cc/";
+    supportLevel = "best-effort";
   };
 
   hardware = {

--- a/boards/libreComputer-amlS805xAc/default.nix
+++ b/boards/libreComputer-amlS805xAc/default.nix
@@ -6,6 +6,7 @@
     name = "La Frite";
     identifier = "libreComputer-amlS805xAc";
     productPageURL = "https://libre.computer/products/s805x/";
+    supportLevel = "supported";
   };
 
   hardware = {

--- a/boards/libreComputer-amlS905xCc/default.nix
+++ b/boards/libreComputer-amlS905xCc/default.nix
@@ -6,6 +6,7 @@
     name = "Le Potato";
     identifier = "libreComputer-amlS805xAc";
     productPageURL = "https://libre.computer/products/aml-s905x-cc/";
+    supportLevel = "best-effort";
   };
 
   hardware = {

--- a/boards/libreComputer-rocRk3399Pc/default.nix
+++ b/boards/libreComputer-rocRk3399Pc/default.nix
@@ -6,6 +6,7 @@
     name = "Renegade Elite";
     identifier = lib.mkDefault "libreComputer-rocRk3399Pc";
     productPageURL = "https://libre.computer/products/rk3399/";
+    supportLevel = "supported";
   };
 
   hardware = {

--- a/boards/odroid-C2/default.nix
+++ b/boards/odroid-C2/default.nix
@@ -15,6 +15,7 @@
     name = "ODROID-C2";
     identifier = "odroid-C2";
     productPageURL = "https://www.hardkernel.com/shop/odroid-c2/";
+    supportLevel = "best-effort";
   };
 
   hardware = {

--- a/boards/odroid-C4/default.nix
+++ b/boards/odroid-C4/default.nix
@@ -6,6 +6,7 @@
     name = "ODROID-C4";
     identifier = "odroid-C4";
     productPageURL = "https://www.hardkernel.com/shop/odroid-c4/";
+    supportLevel = "best-effort";
   };
 
   hardware = {

--- a/boards/odroid-N2/default.nix
+++ b/boards/odroid-N2/default.nix
@@ -6,6 +6,7 @@
     name = "ODROID-N2";
     identifier = "odroid-N2";
     productPageURL = "https://www.hardkernel.com/shop/odroid-n2-with-4gbyte-ram-2/";
+    supportLevel = "best-effort";
   };
 
   hardware = {

--- a/boards/olimex-teresI/default.nix
+++ b/boards/olimex-teresI/default.nix
@@ -4,6 +4,7 @@
     name = "TERES-I";
     identifier = "olimex-teresI";
     productPageURL = "https://www.olimex.com/Products/DIY-Laptop/KITS/TERES-A64-BLACK/open-source-hardware";
+    supportLevel = "best-effort";
   };
 
   hardware = {

--- a/boards/orangePi-pc/default.nix
+++ b/boards/orangePi-pc/default.nix
@@ -4,6 +4,7 @@
     name = "PC";
     identifier = "orangePi-pc";
     productPageURL = "http://www.orangepi.org/orangepipc/";
+    supportLevel = "supported";
   };
 
   hardware = {

--- a/boards/orangePi-pc2/default.nix
+++ b/boards/orangePi-pc2/default.nix
@@ -4,6 +4,7 @@
     name = "PC 2";
     identifier = "orangePi-pc2";
     productPageURL = "http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-PC-2.html";
+    supportLevel = "best-effort";
   };
 
   hardware = {

--- a/boards/orangePi-zeroPlus2H5/default.nix
+++ b/boards/orangePi-zeroPlus2H5/default.nix
@@ -4,6 +4,7 @@
     name = "Zero Plus2 (H5)";
     identifier = "orangePi-zeroPlus2H5";
     productPageURL = "http://www.orangepi.org/OrangePiZeroPlus2/";
+    supportLevel = "supported";
   };
 
   hardware = {

--- a/boards/pine64-pineA64/default.nix
+++ b/boards/pine64-pineA64/default.nix
@@ -4,6 +4,7 @@
     name = "A64";
     identifier = "pine64-pineA64";
     productPageURL = "https://www.pine64.org/devices/single-board-computers/pine-a64/";
+    supportLevel = "best-effort";
   };
 
   hardware = {

--- a/boards/pine64-pineA64LTS/default.nix
+++ b/boards/pine64-pineA64LTS/default.nix
@@ -4,6 +4,7 @@
     name = "A64-LTS";
     identifier = "pine64-pineA64LTS";
     productPageURL = "https://www.pine64.org/devices/single-board-computers/pine-a64-lts/";
+    supportLevel = "supported";
   };
 
   hardware = {

--- a/boards/pine64-pinebookA64/default.nix
+++ b/boards/pine64-pinebookA64/default.nix
@@ -4,6 +4,7 @@
     name = "Pinebook (A64)";
     identifier = "pine64-pinebookA64";
     productPageURL = "https://www.pine64.org/pinebook/";
+    supportLevel = "supported";
   };
 
   hardware = {

--- a/boards/pine64-pinebookPro/default.nix
+++ b/boards/pine64-pinebookPro/default.nix
@@ -6,6 +6,7 @@
     name = "Pinebook Pro";
     identifier = "pine64-pinebookPro";
     productPageURL = "https://www.pine64.org/pinebook-pro/";
+    supportLevel = "supported";
   };
 
   hardware = {

--- a/boards/pine64-pinephoneA64/default.nix
+++ b/boards/pine64-pinephoneA64/default.nix
@@ -6,6 +6,7 @@
     name = "Pinephone (A64)";
     identifier = "pine64-pinephoneA64";
     productPageURL = "https://www.pine64.org/pinephone/";
+    supportLevel = "supported";
   };
 
   hardware = {

--- a/boards/pine64-pinephonePro/default.nix
+++ b/boards/pine64-pinephonePro/default.nix
@@ -6,6 +6,7 @@
     name = "Pinephone Pro";
     identifier = "pine64-pinephonePro";
     productPageURL = "https://www.pine64.org/pinephonepro/";
+    supportLevel = "supported";
   };
 
   hardware = {

--- a/boards/pine64-rockpro64/default.nix
+++ b/boards/pine64-rockpro64/default.nix
@@ -4,6 +4,7 @@
     name = "ROCKPro64";
     identifier = "pine64-rockpro64";
     productPageURL = "https://www.pine64.org/rockpro64/";
+    supportLevel = "best-effort";
   };
 
   hardware = {

--- a/boards/radxa-RockPi4/default.nix
+++ b/boards/radxa-RockPi4/default.nix
@@ -6,6 +6,7 @@
     name = lib.mkDefault "ROCK Pi 4 model A/B";
     identifier = lib.mkDefault "radxa-RockPi4";
     productPageURL = "https://wiki.radxa.com/Rockpi4";
+    supportLevel = "best-effort";
   };
 
   hardware = {

--- a/boards/radxa-zero2/default.nix
+++ b/boards/radxa-zero2/default.nix
@@ -45,6 +45,7 @@ in
     name = "Zero 2";
     identifier = "radxa-zero2";
     productPageURL = "https://wiki.radxa.com/Zero2";
+    supportLevel = "supported";
   };
 
   hardware = {

--- a/boards/raspberryPi-aarch64/default.nix
+++ b/boards/raspberryPi-aarch64/default.nix
@@ -39,6 +39,8 @@ in
     name = "Combined AArch64";
     identifier = lib.mkDefault "raspberryPi-aarch64";
     productPageURL = "https://www.raspberrypi.com/products/";
+    # This line of boards is YMMV.
+    supportLevel = "experimental";
   };
 
   hardware = {

--- a/boards/uBoot-sandbox/default.nix
+++ b/boards/uBoot-sandbox/default.nix
@@ -6,6 +6,7 @@
     name = "Sandbox";
     identifier = "uBoot-sandbox";
     inRelease = false;
+    supportLevel = "unsupported";
   };
 
   hardware = {

--- a/doc/_support/devices/generate-devices-listing.rb
+++ b/doc/_support/devices/generate-devices-listing.rb
@@ -19,6 +19,7 @@ COLUMNS = [
   { key: "device.identifier",   name: "Identifier" },
   { key: "device.name",         name: "Name" },
   { key: "hardware.soc",        name: "SoC" },
+  { key: "device.supportLevel.title", name: "Support level" },
 ]
 
 $out = ENV["out"]
@@ -27,6 +28,11 @@ $devicesInfo = Dir.glob(File.join(ENV["devicesInfo"], "*")).sort.map do |filenam
   [data["device"]["identifier"], data]
 end.to_h
 $devicesDir = ENV["devicesDir"]
+
+supportLevels = $devicesInfo
+  .map { |key, info| info["device"]["supportLevel"] }
+  .sort { |a,b| a["order"] <=> b["order"] }
+  .uniq
 
 # First, generate the devices listing.
 puts ":: Generating devices/index.md"
@@ -81,6 +87,33 @@ File.open(File.join($out, "devices/index.md"), "w") do |file|
 
   file.puts <<~EOF
 
+    <section class="devices-legend">
+
+    <h2>Legend</h2>
+
+    <h3>Support level</h3>
+
+  EOF
+
+  supportLevels.each do |level|
+    file.puts <<~EOF
+
+      <dl>
+        <dt>#{level["title"]}</dt>
+          <dd>#{level["description"].gsub(/\n\n+/, "<br /><br />")}</dd>
+      </dl>
+
+    EOF
+  end
+
+  file.puts <<~EOF
+
+    </section>
+
+  EOF
+
+  file.puts <<~EOF
+
     </div>
   </div>
 
@@ -109,6 +142,8 @@ $devicesInfo.values.each do |info|
           <dd>#{info["device"]["name"]}</dd>
         <dt>Identifier</dt>
           <dd>#{info["device"]["identifier"]}</dd>
+        <dt>Support level</dt>
+          <dd>#{info["device"]["supportLevel"]["title"]}</dd>
         <dt>SoC</dt>
           <dd>#{info["hardware"]["soc"]}</dd>
         <dt>Dedicated firmware storage</dt>

--- a/modules/device.nix
+++ b/modules/device.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ config, lib, ... }:
 
 let
   inherit (lib)
@@ -45,6 +45,13 @@ in
         '';
         default = null;
         type = with types; nullOr str;
+      };
+      supportLevel = mkOption {
+        type = types.enum (builtins.attrNames config.documentation.supportLevelDescriptions);
+        # NO default, the eval should fail if unset!
+        description = ''
+          Support level for the device.
+        '';
       };
     };
   };

--- a/modules/documentation.nix
+++ b/modules/documentation.nix
@@ -47,6 +47,56 @@ in
           '';
         };
       };
+      supportLevelDescriptions = mkOption {
+        type = with types; attrsOf attrs;
+        internal = true;
+        readOnly = true;
+        default = {
+          "supported" = {
+            title = "Supported";
+            description = ''
+              These devices are supported, and regularly verified to work.
+            '';
+            order = 0;
+          };
+          "best-effort" = {
+            title = "Best effort";
+            description = ''
+              These devices are almost supported, but lack regular hardware validation by contributors and maintainers.
+
+              They are likely to work just fine.
+            '';
+            order = 1;
+          };
+          "experimental" = {
+            title = "Experimental";
+            order = 5;
+            description = ''
+              These devices are included in the release builds, and may be verified.
+
+              They may still not work as well as better supported devices, though it is intended to support them as best as possible.
+            '';
+          };
+          "unsupported" = {
+            title = "Unsupported";
+            description = ''
+              These devices are not abandoned, but not supported.
+
+              Lower your expectations.
+            '';
+            order = 10;
+          };
+          "abandoned" = {
+            title = "Abandoned";
+            description = ''
+              These devices are still in the repository, but are unmaintained, and abandoned.
+
+              Expect them to be removed.
+            '';
+            order = 11;
+          };
+        };
+      };
     };
   };
 

--- a/modules/metadata.nix
+++ b/modules/metadata.nix
@@ -42,6 +42,7 @@ in
               productPageURL
             ;
             fullName = "${config.device.manufacturer} ${config.device.name}";
+            supportLevel = config.documentation.supportLevelDescriptions."${config.device.supportLevel}";
           };
           hardware = {
             inherit (config.hardware)


### PR DESCRIPTION
Fixes #242.

* * *

This is to better expose what is the expected support level for boards.

As I don't want to force anything on anyone I have made all boards that I own and support `supported`, anything user-contributed as `best-effort`.

They are morally equivalent, only differing by the fact there is no "dedicated" testing personnel for the given board (yet). Any issues with them is treated the same as it would for supported boards.

Note that I plan to (later) add a *maintainers* (or some other name) value, which will be used as a kind of low-commitment "address book" to find someone to ~~bother~~ gently ask for testing. There will be an assertion requiring `supported` boards to have at least one maintainer listed.

If you own one of those `best-effort` boards, you can prep a PR with the change to `supported`, and your github username added as a comment to the line. This will be used to seed that information later down the line.