### PR TITLE
Tag output with uSWIDs

### DIFF
--- a/modules/tow-boot/builder.nix
+++ b/modules/tow-boot/builder.nix
@@ -19,8 +19,6 @@ let
     version = config.Tow-Boot.uBootVersion;
     structuredConfig = (config.Tow-Boot.structuredConfigHelper version);
   };
-
-  towBootIdentifier = "${config.Tow-Boot.releaseNumber}${config.Tow-Boot.releaseIdentifier}";
 in
 {
   options = {
@@ -240,6 +238,7 @@ in
           uBootVersion
           outputName
           buildUBoot
+          towBootIdentifier
         ;
         inherit (config.Tow-Boot.builder)
           additionalArguments
@@ -250,7 +249,6 @@ in
           postPatch
         ;
         boardIdentifier = config.device.identifier;
-        inherit towBootIdentifier;
       });
 
       builder = {

--- a/modules/tow-boot/builder.nix
+++ b/modules/tow-boot/builder.nix
@@ -98,6 +98,7 @@ in
         , buildInputs
         , nativeBuildInputs
         , postPatch
+        , uswidHelper
         }:
 
         stdenv.mkDerivation ({
@@ -222,6 +223,30 @@ in
             cp .config $out/config/$variant.config
             mkdir -p $out/binaries
             ${installPhase}
+            if test -e $out/binaries; then
+              (
+              echo ":: Adding uSWID data"
+              cd $out/binaries
+              for binary in "${outputName}"*.bin; do
+                printf " - '%s' \n" "$binary"
+                ${/*
+                  Most builds should produce only one output here, but in case other outputs
+                  grow, we'll pre-empt problems by appending the binary name to the tagId.
+
+                  We're referring to tagId as ISO/IEC 19770-2:2015 implies: “a unique
+                  reference for the **specific** […] binary […] If two tagIDs match […] the
+                  underlying products they represent are […] exactly the same”.
+
+                  **Always** treat this tagId as an opaque blob. The useful data it
+                  contains should be found elsewhere.
+                */""}
+                tagId="$(echo $(basename $out)/$binary | sed -e 's/-${stdenv.cc.targetPrefix}/-/')"
+                ${uswidHelper} "$tagId" --compress --save uswid.bin
+                cat uswid.bin >> "$binary"
+                rm uswid.bin
+              done
+              )
+            fi
             runHook postInstall
           '';
 
@@ -249,6 +274,7 @@ in
           postPatch
         ;
         boardIdentifier = config.device.identifier;
+        uswidHelper = config.Tow-Boot.uswid.output.helper;
       });
 
       builder = {

--- a/modules/tow-boot/config.nix
+++ b/modules/tow-boot/config.nix
@@ -15,9 +15,8 @@ let
     releaseRC
     releaseIdentifier
     withLogo
+    towBootIdentifier
   ;
-
-  towBootIdentifier = "${releaseNumber}${releaseRC}${releaseIdentifier}";
 
   # Not actually configurable. This is a constant in Tow-Boot.
   # Changing this will require handling the migration to a larger size.

--- a/modules/tow-boot/default.nix
+++ b/modules/tow-boot/default.nix
@@ -9,5 +9,6 @@
     ./phone-ux.nix
     ./smbios.nix
     ./src.nix
+    ./uswid.nix
   ];
 }

--- a/modules/tow-boot/options.nix
+++ b/modules/tow-boot/options.nix
@@ -92,6 +92,11 @@ in
           RC part of the tag, for pre-release management.
         '';
       };
+      towBootIdentifier = mkOption {
+        internal = true;
+        readOnly = true;
+        default = "${config.Tow-Boot.releaseNumber}${config.Tow-Boot.releaseRC}${config.Tow-Boot.releaseIdentifier}";
+      };
 
       defconfig = mkOption {
         type = types.str;

--- a/modules/tow-boot/uswid.nix
+++ b/modules/tow-boot/uswid.nix
@@ -1,0 +1,128 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    concatStringsSep
+    mkOption
+    optional
+    types
+  ;
+
+  inherit (config.Tow-Boot)
+    outputName
+    towBootIdentifier
+    uBootVersion
+    variant
+  ;
+
+  inherit (config)
+    device
+  ;
+
+  #
+  # For the definition of the fields, refer to:
+  #
+  #  - ISO/IEC 19770-2:2015 (Preferred)
+  #      - https://standards.iso.org/iso/19770/-2/2015/schema.xsd
+  #      - https://web.archive.org/web/20230824211322/https://standards.iso.org/iso/19770/-2/2015/schema.xsd
+  #
+  #  - RFC9393 (Adequate)
+  #      - https://datatracker.ietf.org/doc/html/rfc9393
+  #
+  #  - NIST.IR 8060 (Okay, too)
+  #      - https://nvlpubs.nist.gov/nistpubs/ir/2016/NIST.IR.8060.pdf
+  #
+  uSWIDData = {
+    "uSWID" = {
+      # Will be replaced during execution with basename of $out (guaranteed meaningfully unique)
+      # DO NOT assume any useful form when consuming the SWID.
+      tag-id = "$id";
+
+      # (Unchanging) meaningful name for end-user
+      software-name = "${outputName} for ${device.name} [variant: ${variant}]";
+
+      # Short description for the software (shown in e.g. fwupd frontends)
+      summary = "An opinionated distribution of U-Boot";
+
+      # Lexicographically sortable version name
+      # (pre/post suffixes will not sort as expected, but that is okay)
+      software-version = "${"${uBootVersion}-${towBootIdentifier}"}";
+      version-scheme = "multipartnumeric+suffix";
+
+      # Tow-Boot or U-Boot, depending on how the tooling is used.
+      product = outputName;
+
+      # An identifier (GUID suggested) that refers to a "set of software components that are related",
+      # "but may be different versions".
+      #
+      # We're using the device identifier and variant here, since the only "related"
+      # components would be the same board, same variant components here.
+      # Changing from one variant to another is a "major" change all things considered.
+      #
+      # When tracking updates, assuming the same `persistent-id` works on the same system is okay.
+      persistent-id = "org.Tow-Boot.${outputName}.${device.identifier}.${variant}";
+    };
+    # The entity producing this tag...
+    "uSWID-Entity:TagCreator" = {
+      name = "Tow-Boot";
+      regid = "tow-boot.org";
+      # ... And its role(s) with regard to the software.
+      # "pre-defined roles include: aggregator, distributor, licensor, softwareCreator, tagCreator"
+      extra-roles = concatStringsSep "," (
+        [
+          # Distributor assumed to mean "provides binaries"
+          "Distributor"
+          "Licensor"
+          "Maintainer"
+        ]
+        # Creator of the "distribution"
+        ++ (optional (outputName == "Tow-Boot") "SoftwareCreator")
+      );
+    };
+  };
+in
+{
+  options = {
+    Tow-Boot.uswid = {
+      output = {
+        helper = mkOption {
+          type = types.package;
+          internal = true;
+          description = ''
+            Helper script filling most details for the uSWID.
+
+            Only missing input is the `tag-id`, passed as the first argument.
+          '';
+        };
+      };
+    };
+  };
+  config = {
+    Tow-Boot.uswid.output.helper = pkgs.buildPackages.callPackage (
+      { lib
+      , writeShellScript
+      , Tow-Boot
+      , uSWIDData
+      }:
+      writeShellScript "generate-uswid" ''
+        set -e
+        set -u
+        PS4=" $ "
+
+        id="$1"
+        shift
+
+        cat > uswid.tmp.ini <<EOF
+        ${lib.generators.toINI {} uSWIDData}
+        EOF
+        (
+        set -x
+        ${Tow-Boot.uswid}/bin/uswid --load uswid.tmp.ini "$@"
+        )
+        rm uswid.tmp.ini
+      ''
+    ) {
+      inherit uSWIDData;
+    };
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -15,7 +15,7 @@ let
   };
 
   # We're slightly cheating here
-  version = "${anonymousEval.config.Tow-Boot.uBootVersion}-${anonymousEval.config.Tow-Boot.releaseNumber}${anonymousEval.config.Tow-Boot.releaseIdentifier}";
+  version = "${anonymousEval.config.Tow-Boot.uBootVersion}-${anonymousEval.config.Tow-Boot.towBootIdentifier}";
 
   release-tools = import ./support/nix/release-tools.nix { inherit pkgs; };
 in

--- a/support/overlay/overlay.nix
+++ b/support/overlay/overlay.nix
@@ -74,6 +74,8 @@ in
 
     meson64-tools = callPackage ./meson64-tools { };
 
+    uswid = final.python3Packages.callPackage ./uswid { };
+
     mkScript = file: final.runCommand "out.scr" {
       nativeBuildInputs = [
         final.buildPackages.ubootTools

--- a/support/overlay/uswid/default.nix
+++ b/support/overlay/uswid/default.nix
@@ -1,0 +1,23 @@
+{ buildPythonPackage
+, fetchPypi
+
+, cbor2
+, lxml
+, pefile
+}:
+
+buildPythonPackage rec {
+  pname = "uswid";
+  version = "0.4.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-pCZwa6IB2XgFHP8opzdtp5B015v4dqmvRt2s2mlXhLM=";
+  };
+
+  propagatedBuildInputs = [
+    cbor2
+    lxml
+    pefile
+  ];
+}


### PR DESCRIPTION
Fixes #129

* * *

With these changes, we now append an uSWID to the actual Tow-Boot "binaries", which in turn should unblock future work around fwupd.


```
~/.../Tow-Boot/uswid $ ./result-uswid/bin/uswid --load result/binaries/Tow-Boot.mmcboot.bin --save uswid.xml
Found USWID header at offset: 817665
```

```xml
<?xml version='1.0' encoding='utf-8'?>
<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" xmlns:SHA512="http://www.w3.org/2001/04/xmlenc#sha512" xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xml:lang="en-US" name="Tow-Boot for Pinebook (A64) [variant: mmcboot]" tagId="qnhl8243ns10vpcg0x1nbx7dwp3p0gjb-Tow-Boot-pinebook_defconfig-mmcboot-aarch64-unknown-linux-gnu-2023.07-007-rc1-pre" version="2023.07-007-rc1-pre" versionScheme="multipartnumeric+suffix">
  <Entity name="Tow-Boot" regid="tow-boot.org" role="tagCreator licensor maintainer softwareCreator"/>
  <Meta product="Tow-Boot" persistentId="org.tow-boot.tow-boot"/>
</SoftwareIdentity>
```

And the ini from the uSWID:

```ini
[uSWID]
tag-id = qnhl8243ns10vpcg0x1nbx7dwp3p0gjb-Tow-Boot-pinebook_defconfig-mmcboot-aarch64-unknown-linux-gnu-2023.07-007-rc1-pre
software-name = Tow-Boot for Pinebook (A64) [variant: mmcboot]
software-version = 2023.07-007-rc1-pre
version-scheme = multipartnumeric+suffix
summary = An opinionated distribution of U-Boot
product = Tow-Boot
persistent-id = org.tow-boot.tow-boot

[uSWID-Entity:TagCreator]
name = Tow-Boot
regid = tow-boot.org
extra-roles = Licensor,Maintainer,SoftwareCreator
```

* * *

cc @DylanVanAssche, @hughsie, especially regarding fwupd, is there anything outright problematic in here?

I've used [NISTIR 8060 Guidelines for the Creation of Interoperable Software Identification (SWID) Tags](https://nvlpubs.nist.gov/nistpubs/ir/2016/NIST.IR.8060.pdf) as a source of truth to know what tags meant, and their *required* state or not. But I don't assume I've understood all and how it applies in practice here.

<del>(Note that the empty *evidence* values are currently a workaround, see https://github.com/hughsie/python-uswid/issues/53.)</del>

Now, what's up with that weird `tag-id`?? Glad you asked! It's the basename of the Nix store path for the build of the binary. They are a hash encapsulating the whole derivation, which includes the whole build environment. Hopefully that is not a problematic `tag-id` to use, as not only is it convenient, it is actively unique to the whole stack used to produce the build *including what was used to produce the uSWID*.

### About git revision

Adding the git revision used for the build *could* be done, but is kind of unergonomic when referring to the repository in which the expressions reside. The best way to do it would be "from the outside" when e.g. building the project, passing `--argstr rev "$(...)"`.

It might be worth it to add more useful information for the build, but would be reserved, I suppose, for release builds mainly, and is really orthogonal to these changes. It wouldn't be hard to add it in the SWID after the fact. 