### PR TITLE
Mark 007-rc2

### DIFF
--- a/modules/tow-boot/identity.nix
+++ b/modules/tow-boot/identity.nix
@@ -1,7 +1,7 @@
 {
   Tow-Boot = {
     releaseNumber = "007";
-    releaseRC = "-rc1";
+    releaseRC = "-rc2";
     releaseIdentifier = "-pre";
   };
 }

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -73,6 +73,7 @@ in
         };
         Tow-Boot = {
           "tb-2023.07-007-rc1" = "sha256-vAB7MHn5VZEo3fPR7zWADpUMJ14Una90JrXRSPI9T9U=";
+          "tb-2023.07-007-rc2" = "sha256-ENE2bSPUfdFqXLmZFBWfYS/sJ6sXqPr2QjO0XdFzido=";
         };
       };
 


### PR DESCRIPTION
Solves issues with Amlogic (meson) boot order and MMC naming.

See:

 - `git diff tb-2023.07-007-rc1..tb-2023.07-007-rc2`
 - https://github.com/Tow-Boot/U-Boot/compare/tb-2023.07-007-rc1..tb-2023.07-007-rc2


<details><summary>Old PR body</summary>
As I briefly touched on elsewhere, all my amlogic boards are *weird*.

I'd really like someone to verify it fixes the predictable boot order issue.

**IMPORTANT NOTE**: If you have saved an environment to SPI flash, you will need to wipe the whole SPI flash (or the env, if you know how to), as otherwise your test will be invalid.

 - Closes #249
 - Closes #268
 - Closes #269 (I believe)

So we were off by one, decrement all indices by one, and finally add a fallback for the mmc2 interface *just in case*.

* * *

NOTE: this PR's commit will be tagged `rc2`, and this tag will switch from `-rc1` to `-rc2` once tested.

* * *

```
.../u-boot/Tow-Boot $ git diff tow-tb-2023.07-007-rc1..897506f457f6adef6b24f2f5a10739d39d8331a8
```

```diff
diff --git a/include/configs/meson64.h b/include/configs/meson64.h
index 33e45668aa8..c98ef592480 100644
--- a/include/configs/meson64.h
+++ b/include/configs/meson64.h
@@ -72,10 +72,11 @@
 
 #if defined(CONFIG_TOW_BOOT_PREDICTABLE_BOOT_PREFER_INTERNAL)
 #define BOOT_TARGET_DEVICES(func) \
-       func(MMC, mmc, 2) /* eMMC */ \
+       func(MMC, mmc, 1) /* eMMC */ \
        BOOT_TARGET_NVME(func) \
        BOOT_TARGET_SCSI(func) \
-       func(MMC, mmc, 1) /* SD */ \
+       func(MMC, mmc, 0) /* SD */ \
+       func(MMC, mmc, 2) /* (generally sdio) */ \
        BOOT_TARGET_DEVICES_USB(func) \
        func(PXE, pxe, na) \
        func(DHCP, dhcp, na) \
@@ -83,10 +84,11 @@
 #elif defined(CONFIG_TOW_BOOT_PREDICTABLE_BOOT_PREFER_EXTERNAL)
 #define BOOT_TARGET_DEVICES(func) \
        BOOT_TARGET_DEVICES_USB(func) \
-       func(MMC, mmc, 1) /* SD */ \
+       func(MMC, mmc, 0) /* SD */ \
        BOOT_TARGET_SCSI(func) \
        BOOT_TARGET_NVME(func) \
-       func(MMC, mmc, 2) /* eMMC */ \
+       func(MMC, mmc, 1) /* eMMC */ \
+       func(MMC, mmc, 2) /* (generally sdio) */ \
        func(PXE, pxe, na) \
        func(DHCP, dhcp, na) \
        func(ROMUSB, romusb, na)
```