### PR TITLE
Add support for FriendlyElec NanoPi M1 Plus

### DIFF
--- a/boards/friendlyElec-nanoPiM1Plus/default.nix
+++ b/boards/friendlyElec-nanoPiM1Plus/default.nix
@@ -1,0 +1,19 @@
+{
+  device = {
+    manufacturer = "FriendlyELEC";
+    name = "NanoPi M1 Plus";
+    identifier = "friendlyElec-nanoPiM1Plus";
+    productPageURL = "https://www.friendlyelec.com/index.php?route=product/product&path=69&product_id=176";
+    supportLevel = "best-effort";
+  };
+
+  hardware = {
+    soc = "allwinner-h3";
+    allwinner.crust.defconfig = "nanopi_m1_plus_defconfig";
+    mmcBootIndex = "1";
+  };
+
+  Tow-Boot = {
+    defconfig = "nanopi_m1_plus_defconfig";
+  };
+}


### PR DESCRIPTION
Hello!

What was tested:
1. Tow-Boot start from microSD.
2. Tow-Boot installation to eMMC.
3. Tow-Boot start from eMMC.
4. UEFI boot from eMMC  
5. UEFI boot from microSD
6. UEFI boot from USB

Although Debian 12.2 installer can not mount itself from microSD for some reason, microSD with installed Debian armhf boot just fine (item 5).
Debian installer works without issues if it's on USB flash drive or USB card-reader.