### PR TITLE
Add mmcboot installer for ODROID-C4

### DIFF
--- a/boards/odroid-C4/default.nix
+++ b/boards/odroid-C4/default.nix
@@ -11,6 +11,7 @@
 
   hardware = {
     soc = "amlogic-s905x3";
+    mmcBootIndex = "1";
   };
 
   Tow-Boot = {


### PR DESCRIPTION
Hello!

This change was tested on top of https://github.com/Tow-Boot/Tow-Boot/pull/274 

Created mmcboot.installer.img was able to update Tow-Boot on eMMC to a new version that include boot order fix.