### PR TITLE
rockchip: Use the "new" sysreset poweroff implementation

### DIFF
--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -97,6 +97,17 @@ in
       };
     })
 
+    (mkIf (anyRockchip) {
+      Tow-Boot = {
+        config = [
+          (helpers: with helpers; {
+            CMD_POWEROFF = yes;
+            SYSRESET_CMD_POWEROFF = yes;
+          })
+        ];
+      };
+    })
+
     # Documentation fragments
     (mkIf (anyRockchip && !isPhoneUX) {
       documentation.sections.installationInstructions =

--- a/modules/tow-boot/identity.nix
+++ b/modules/tow-boot/identity.nix
@@ -1,7 +1,7 @@
 {
   Tow-Boot = {
     releaseNumber = "007";
-    releaseRC = "-rc2";
+    releaseRC = "-rc3";
     releaseIdentifier = "-pre";
   };
 }

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -74,6 +74,7 @@ in
         Tow-Boot = {
           "tb-2023.07-007-rc1" = "sha256-vAB7MHn5VZEo3fPR7zWADpUMJ14Una90JrXRSPI9T9U=";
           "tb-2023.07-007-rc2" = "sha256-ENE2bSPUfdFqXLmZFBWfYS/sJ6sXqPr2QjO0XdFzido=";
+          "tb-2023.07-007-rc3" = "sha256-/eKHISaHLiNikk4gWoOSIPd2D3xiG1A/TSGUPEzhfZQ=";
         };
       };
 


### PR DESCRIPTION
Added last year, so not that new, but wasn't there when the patch set was implemented.

This change drops the (bad) poweroff forward port from the vendor code,
since U-Boot grew the feature to do poweroff *correctly* on Rockchip
platforms, since.

I only noticed this while working on [REDACTED] rk3566 enablement, which
had an rk817, and would have needed support to be added... but saw
relevant code implying I didn't need to.

See also:

 - ` $ git diff tb-2023.07-007-rc2..f1252aa37371256cf4da68107c4d03906ab7aebb`
 - https://github.com/samueldr/u-boot/compare/tb-2023.07-007-rc2..wip/tb2307/rockchip-sysreset-poweroff

### Things done

 - Tested this change on an unnamed rk3566 device (it powered off, wouldn't with the insufficient patches)
 - Tested on Pinebook Pro
 - Tested on Pinephone Pro

Checked, all boards currently in Tow-Boot use either rk808, or rk818 (only the Pinephone Pro), so with the rk817 from the unspecified system, I think ***this*** change set is complete.

### Things to do

(Nothing)

* * *

Moving this to the next milestone isn't a problem, if it ends-up not working on a supported platform. It's mostly a cleanup by removing code. Otherwise this change should functionally be a no-op for end-users.