### PR TITLE
Tow-Boot: update to -rc4 (rockchip + pinephonePro)

### DIFF
--- a/boards/pine64-pinephonePro/default.nix
+++ b/boards/pine64-pinephonePro/default.nix
@@ -44,7 +44,9 @@
         CMD_POWEROFF = lib.mkForce yes;
       })
       (helpers: with helpers; {
-        # Workarounds required for eMMC issues and current patchset.
+        # NOTE: works around an issue with the config, where we hit:
+        #     mmc fail to send stop cmd
+        #     ** fs_devread read error - block
         MMC_IO_VOLTAGE = yes;
         MMC_SDHCI_SDMA = yes;
         MMC_SPEED_MODE_SET = yes;

--- a/modules/tow-boot/identity.nix
+++ b/modules/tow-boot/identity.nix
@@ -1,7 +1,7 @@
 {
   Tow-Boot = {
     releaseNumber = "007";
-    releaseRC = "-rc3";
+    releaseRC = "-rc4";
     releaseIdentifier = "-pre";
   };
 }

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -75,6 +75,7 @@ in
           "tb-2023.07-007-rc1" = "sha256-vAB7MHn5VZEo3fPR7zWADpUMJ14Una90JrXRSPI9T9U=";
           "tb-2023.07-007-rc2" = "sha256-ENE2bSPUfdFqXLmZFBWfYS/sJ6sXqPr2QjO0XdFzido=";
           "tb-2023.07-007-rc3" = "sha256-/eKHISaHLiNikk4gWoOSIPd2D3xiG1A/TSGUPEzhfZQ=";
+          "tb-2023.07-007-rc4" = "sha256-qEVvvnKy3fdFmU7Qn1U2PMqhf8p228v6+4XtkVGgQgk=";
         };
       };
 


### PR DESCRIPTION
I'm misusing this to also handle https://github.com/Tow-Boot/U-Boot/pull/3

Fixes #297

* * *


Apparently I left a bunch of the work incomplete for the Pinephone Pro, as I hadn't verified that stuff like the buttons, LED and vibrator had their bindings.

With this change set, only those critical parts have been ported forward. We'll try not to stray too far from the upstream DT, and with the inevitable sync with mainline, we'll try to make it work even better.

Also adds back a change that removes an `iodomain` change, which breaks SPI Flash in e.g. the installer.

Finally, update a comment so I know why those config changes are required.

 - https://github.com/samueldr/u-boot/compare/tb-2023.07-007-rc3..wip/tb2307/ppp-dt

### What was done

 - Tested on Pinephone Pro, buttons, vibration and LED pattern started working again.

There is no difference for any other platform.

* * *
