### PR TITLE
modules/tow-boot: Fix missing bootdelay argument in AUTOBOOT_PROMPT

### DIFF
--- a/modules/tow-boot/config.nix
+++ b/modules/tow-boot/config.nix
@@ -60,7 +60,7 @@ in
           bright = "\\e[1m";
         in
         lib.mkIf (!config.Tow-Boot.buildUBoot) (
-          freeform ''"${reset}Please press [${bright}ESCAPE${reset}] or [${bright}CTRL+C${reset}] to enter the boot menu."''
+          freeform ''"${reset}Please press [${bright}ESCAPE${reset}] or [${bright}CTRL+C${reset}] to enter the boot menu in %ds."''
         )
       ;
 


### PR DESCRIPTION
printf(CONFIG_AUTOBOOT_PROMPT, bootdelay) takes bootdelay argument to print the value upon bootup. CONFIG_AUTOBOOT_PROMPT includes the %d for all boards. Add %d to Tow-Boot AUTOBOOT_PROMPT.

Additionally that would help to understand, why it's not possible to enter tb_menu using keys on a phone variant over UART. [1]

1. https://github.com/Tow-Boot/Tow-Boot/issues/289