### PR TITLE
Add support for FriendlyElec NanoPi R4S

### DIFF
--- a/boards/friendlyElec-nanoPiR4S/default.nix
+++ b/boards/friendlyElec-nanoPiR4S/default.nix
@@ -1,0 +1,17 @@
+{
+  device = {
+    manufacturer = "FriendlyELEC";
+    name = "NanoPi R4S";
+    identifier = "friendlyElec-nanoPiR4S";
+    productPageURL = "https://wiki.friendlyelec.com/wiki/index.php/NanoPi_R4S";
+    supportLevel = "best-effort";
+  };
+
+  hardware = {
+    soc = "rockchip-rk3399";
+  };
+
+  Tow-Boot = {
+    defconfig = "nanopi-r4s-rk3399_defconfig";
+  };
+}


### PR DESCRIPTION
FriendlyElec NanoPi R4S is an SBC based on RK3399.

The standard model has no eMMC (there's an "enterprise" edition with this, which I do not have) nor SPI flash (although SPI1 is available on a small GPIO header, so it can be added).

What's tested:

- Tow-Boot is flashed to shared storage on SD card.
- Console is available on serial header.
- UEFI boot with NixOS 23.11 USB ISO.