### PR TITLE
rk3399: move ramdisk_addr_r for larger kernels

### DIFF
--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -47,6 +47,9 @@ in
     (mkIf cfg.rockchip-rk3399.enable {
       system.system = "aarch64-linux";
       Tow-Boot = {
+        patches = [
+          ./rk3399-big-kernel.patch
+        ];
         config = mkIf withSPI [
           (helpers: with helpers; {
             # SPI boot Support

--- a/modules/hardware/rockchip/rk3399-big-kernel.patch
+++ b/modules/hardware/rockchip/rk3399-big-kernel.patch
@@ -1,0 +1,13 @@
+diff --git a/include/configs/rk3399_common.h b/include/configs/rk3399_common.h
+index 96ba19c659..eef8657258 100644
+--- a/include/configs/rk3399_common.h
++++ b/include/configs/rk3399_common.h
+@@ -39,7 +39,7 @@
+ 	"fdt_addr_r=0x01f00000\0" \
+ 	"fdtoverlay_addr_r=0x02000000\0" \
+ 	"kernel_addr_r=0x02080000\0" \
+-	"ramdisk_addr_r=0x06000000\0" \
++	"ramdisk_addr_r=0x08000000\0" \
+ 	"kernel_comp_addr_r=0x08000000\0" \
+ 	"kernel_comp_size=0x2000000\0"
+ 


### PR DESCRIPTION
The NixOS Linux 6.7 kernel is too big to fit in the 63.5MiB of space allocated in the U-Boot config. This temporary fix adds an additional 32MiB of space for the kernel.

I tested this on a PineBook Pro but do not have any other RK3399 devices to test. It would be useful of U-Boot didn't hardcode initrd position but that would be a much more invasive change than this.