### PR TITLE
Cleanup Rockchip workarounds and implementation

### DIFF
--- a/boards/odroid-N2/default.nix
+++ b/boards/odroid-N2/default.nix
@@ -1,5 +1,11 @@
-{ lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
+let
+  inherit (lib)
+    mkIf
+  ;
+  inherit (config.Tow-Boot) buildUBoot;
+in
 {
   device = {
     manufacturer = "Hardkernel";
@@ -11,7 +17,8 @@
 
   hardware = {
     soc = "amlogic-s922x";
-    SPISize = 8 * 1024 * 1024;
+    # Only enable SPI build with Tow-Boot; mainline doesn't have the patch.
+    SPISize = mkIf (!buildUBoot) (8 * 1024 * 1024);
   };
 
   Tow-Boot = {
@@ -20,7 +27,7 @@
       (helpers: with helpers; {
         USE_PREBOOT = yes;
         PREBOOT = freeform ''"usb start ; usb info"'';
-        SF_DEFAULT_SPEED = freeform ''52000000'';
+        SF_DEFAULT_SPEED = mkIf (!buildUBoot) (freeform ''52000000'');
       })
     ];
     builder.additionalArguments = {

--- a/boards/pine64-pinephoneA64/default.nix
+++ b/boards/pine64-pinephoneA64/default.nix
@@ -1,5 +1,12 @@
 { config, lib, pkgs, ... }:
 
+let
+  inherit (lib)
+    mkMerge
+    mkIf
+  ;
+  inherit (config.Tow-Boot) buildUBoot;
+in
 {
   device = {
     manufacturer = "PINE64";
@@ -27,17 +34,18 @@
         mmcEMMC = "1";
       };
     };
-    config = [
-      (helpers: with helpers; {
+    config = mkMerge [
+      [(helpers: with helpers; {
+        USB_MUSB_GADGET = yes;
+        USB_GADGET_MANUFACTURER = freeform ''"Pine64"'';
+      })]
+      # Requires Tow-Boot patches
+      (mkIf (!buildUBoot) [(helpers: with helpers;{
         BUTTON_GPIO = yes;
         BUTTON_SUN4I_LRADC = yes;
         LED_GPIO = yes;
         VIBRATOR_GPIO = yes;
-      })
-      (helpers: with helpers; {
-        USB_MUSB_GADGET = yes;
-        USB_GADGET_MANUFACTURER = freeform ''"Pine64"'';
-      })
+      })])
     ];
     touch-installer = {
       targetBlockDevice = "/dev/mmcblk2boot0";

--- a/boards/pine64-pinephonePro/default.nix
+++ b/boards/pine64-pinephonePro/default.nix
@@ -1,5 +1,12 @@
 { config, lib, pkgs, ... }:
 
+let
+  inherit (lib)
+    mkMerge
+    mkIf
+  ;
+  inherit (config.Tow-Boot) buildUBoot;
+in
 {
   device = {
     manufacturer = "PINE64";
@@ -27,18 +34,10 @@
         mmcEMMC = "0";
       };
     };
-    config = [
+    config = mkMerge [
+      [
       (helpers: with helpers; {
         TOW_BOOT_QUIRK_ROCKCHIP_DISABLE_DOWNLOAD_MODE = lib.mkIf (!config.Tow-Boot.buildUBoot) yes;
-      })
-      (helpers: with helpers; {
-        BUTTON_GPIO = yes;
-        BUTTON_ADC = yes;
-        LED_GPIO = yes;
-        VIBRATOR_GPIO = yes;
-      })
-      (helpers: with helpers; {
-        USB_GADGET_MANUFACTURER = freeform ''"Pine64"'';
       })
       (helpers: with helpers; {
         CMD_POWEROFF = lib.mkForce yes;
@@ -54,6 +53,15 @@
         MMC_HS400_ES_SUPPORT = yes;
         MMC_HS400_SUPPORT = yes;
       })
+      ]
+      # Requires Tow-Boot patches
+      (mkIf (!buildUBoot) [(helpers: with helpers;{
+        BUTTON_GPIO = yes;
+        BUTTON_ADC = yes;
+        LED_GPIO = yes;
+        VIBRATOR_GPIO = yes;
+        USB_GADGET_MANUFACTURER = freeform ''"Pine64"'';
+      })])
     ];
   };
   documentation.sections.installationInstructions = builtins.readFile ./INSTALLING.md;

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -14,6 +14,7 @@ let
   ;
   inherit (config.Tow-Boot)
     variant
+    uBootVersion
   ;
   cfg = config.hardware.socs;
   withSPI = config.hardware.SPISize != null;
@@ -52,8 +53,12 @@ in
             # SPI boot Support
             MTD = yes;
             DM_MTD = yes;
+            ROCKCHIP_SPI_IMAGE = mkIf (versionAtLeast uBootVersion "2022.10") yes;
             SPI_FLASH_SFDP_SUPPORT = yes;
             SPL_DM_SPI = yes;
+            SPL_SPI_FLASH_SUPPORT = yes;
+            SPL_SPI_LOAD = yes;
+            SPL_SPI = yes;
             SPL_SPI_FLASH_TINY = no;
             SPL_SPI_FLASH_SFDP_SUPPORT = yes;
             # NOTE: Some boards may have a different value:

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -56,6 +56,12 @@ in
             SPL_DM_SPI = yes;
             SPL_SPI_FLASH_TINY = no;
             SPL_SPI_FLASH_SFDP_SUPPORT = yes;
+            # NOTE: Some boards may have a different value:
+            #   ~/tmp/u-boot/u-boot $ grep -l -R 'u-boot,spl-payload-offset' arch/*/dts/rk*.dts*
+            #    arch/arm/dts/rk3368-lion-haikou-u-boot.dtsi
+            #    arch/arm/dts/rk3399-gru-u-boot.dtsi
+            #    arch/arm/dts/rk3399-puma-haikou-u-boot.dtsi
+            # Not an issue currently.
             SYS_SPI_U_BOOT_OFFS = freeform ''0x80000''; # 512K
             SPL_DM_SEQ_ALIAS = yes;
           })
@@ -105,6 +111,21 @@ in
             SYSRESET_CMD_POWEROFF = yes;
           })
         ];
+        builder.postPatch =
+          # The baud rate needs to be patched out to match the `CONFIG_BAUDRATE` value,
+          # since this `chosen/stdout-path` value serves as the default if no `console=` param exists.
+          # I don't know if it's possible with the tooling of U-Boot upstream, but if it is, they should sync that.
+          ''
+            echo ':: Patching stdout baud rate in rockchip device trees'
+            (PS4=" $ "
+            for f in arch/arm/dts/*rk3*.dts*; do
+              (set -x
+              sed -i -e 's/serial2:1500000n8/serial2:115200n8/' "$f"
+              )
+            done
+            )
+          ''
+        ;
       };
     })
 

--- a/modules/tow-boot/builder.nix
+++ b/modules/tow-boot/builder.nix
@@ -15,7 +15,7 @@ let
 
   evaluatedStructuredConfig = import ../../support/nix/eval-kconfig.nix rec {
     inherit lib;
-    inherit (pkgs) path;
+    inherit (pkgs) path writeShellScript;
     version = config.Tow-Boot.uBootVersion;
     structuredConfig = (config.Tow-Boot.structuredConfigHelper version);
   };

--- a/modules/tow-boot/config.nix
+++ b/modules/tow-boot/config.nix
@@ -64,6 +64,9 @@ in
         )
       ;
 
+      # Normalize baud rate across all platforms
+      BAUDRATE = freeform "115200";
+
       # And this ends up causing the menu to be used on ESCAPE (or CTRL+C)
       AUTOBOOT_USE_MENUKEY = yes;
 

--- a/support/nix/eval-kconfig.nix
+++ b/support/nix/eval-kconfig.nix
@@ -4,6 +4,7 @@
 , modules ? []
 , structuredConfig
 , version
+, writeShellScript
 }: rec {
   module = import (path + "/nixos/modules/system/boot/kernel_config.nix");
   config = (lib.evalModules {
@@ -42,7 +43,7 @@
           mkConf = cfg: lib.concatStringsSep "\n" (lib.mapAttrsToList mkConfigLine cfg);
           configfile = mkConf config.settings;
 
-          validatorSnippet = ''
+          validatorSnippet = writeShellScript "kernel-configuration-validator-snippet" ''
             (
             echo
             echo ":: Validating kernel configuration"
@@ -61,7 +62,6 @@
               line = lib.escapeShellArg (mkConfigLine key item);
               escapedLinePattern = lib.replaceStrings ["[" "]" ''\''] [ ''\['' ''\]'' ''\\''] line;
               lineNotSet = "# CONFIG_${key} is not set";
-              linePattern = "^CONFIG_${key}=";
               presencePattern = "CONFIG_${key}[ =]";
             in
             ''
@@ -150,9 +150,9 @@
             };
             validatorSnippet = lib.mkOption {
               readOnly = true;
-              type = lib.types.str;
+              type = lib.types.package;
               description = ''
-                String that can directly be used as a kernel config file contents.
+                Path to a script that can directly be called to validate the kernel config.
               '';
             };
           };


### PR DESCRIPTION
This cleans up the rockchip-specific implementation bits for many reasons. One of them is an upcoming cleanup for "better supporting" building stock U-Boot. Another would be to future-proof against adding other Rockchip boards :eyes:.

This builds on top of #311.

* * *

This is (lightly) blocked on efead54f2d562ff841b56d930ff967e03986d379 needing to verified by @CRTified's shenanigans around adding an SPI Flash to a board where the default setup, the defconfig and DT don't have it configured.

This will not affect other platforms in wrong ways, AFAIUI, only might be missing some defconfig to add SPI support without touching the defconfig files.