### PR TITLE
tow-boot/builder: pass config validation as a package

### DIFF
--- a/modules/tow-boot/builder.nix
+++ b/modules/tow-boot/builder.nix
@@ -15,7 +15,7 @@ let
 
   evaluatedStructuredConfig = import ../../support/nix/eval-kconfig.nix rec {
     inherit lib;
-    inherit (pkgs) path;
+    inherit (pkgs) path writeShellScript;
     version = config.Tow-Boot.uBootVersion;
     structuredConfig = (config.Tow-Boot.structuredConfigHelper version);
   };

--- a/support/nix/eval-kconfig.nix
+++ b/support/nix/eval-kconfig.nix
@@ -4,6 +4,7 @@
 , modules ? []
 , structuredConfig
 , version
+, writeShellScript
 }: rec {
   module = import (path + "/nixos/modules/system/boot/kernel_config.nix");
   config = (lib.evalModules {
@@ -42,7 +43,7 @@
           mkConf = cfg: lib.concatStringsSep "\n" (lib.mapAttrsToList mkConfigLine cfg);
           configfile = mkConf config.settings;
 
-          validatorSnippet = ''
+          validatorSnippet = writeShellScript "kernel-configuration-validator-snippet" ''
             (
             echo
             echo ":: Validating kernel configuration"
@@ -61,7 +62,6 @@
               line = lib.escapeShellArg (mkConfigLine key item);
               escapedLinePattern = lib.replaceStrings ["[" "]" ''\''] [ ''\['' ''\]'' ''\\''] line;
               lineNotSet = "# CONFIG_${key} is not set";
-              linePattern = "^CONFIG_${key}=";
               presencePattern = "CONFIG_${key}[ =]";
             in
             ''
@@ -150,9 +150,9 @@
             };
             validatorSnippet = lib.mkOption {
               readOnly = true;
-              type = lib.types.str;
+              type = lib.types.package;
               description = ''
-                String that can directly be used as a kernel config file contents.
+                Path to a script that can directly be called to validate the kernel config.
               '';
             };
           };


### PR DESCRIPTION
Otherwise the big script gets passed around as an argument and simply is too big.

See also Mobile NixOS [`d21e6dad77de0383cbb17c78a5299fb691eb89a8`](https://github.com/NixOS/mobile-nixos/commit/d21e6dad77de0383cbb17c78a5299fb691eb89a8).

* * *

A trivial change, but will be needed as it is *soon* becoming required. The generated derivation gets too big otherwise.