### PR TITLE
 tow-boot/builder: Drop platform-specific hacks and cleanup + unify baud rate

### DIFF
--- a/modules/tow-boot/config.nix
+++ b/modules/tow-boot/config.nix
@@ -64,6 +64,9 @@ in
         )
       ;
 
+      # Normalize baud rate across all platforms
+      BAUDRATE = freeform "115200";
+
       # And this ends up causing the menu to be used on ESCAPE (or CTRL+C)
       AUTOBOOT_USE_MENUKEY = yes;
 


### PR DESCRIPTION
This removes the last platform-specific hacks in the generic builder option.

See also: #309.