### PR TITLE
Improve "diffing" of Tow-Boot

### DIFF
--- a/boards/raspberryPi-aarch64/default.nix
+++ b/boards/raspberryPi-aarch64/default.nix
@@ -82,12 +82,14 @@ in
           ;
         } ''
           (PS4=" $ "; set -x
-          mkdir -p $out/{binaries,config}
+          mkdir -p $out/{binaries,config,diff}
           cp -v ${raspberryPi-3.config.Tow-Boot.outputs.firmware}/binaries/Tow-Boot.noenv.bin $out/binaries/Tow-Boot.noenv.rpi3.bin
           cp -v ${raspberryPi-3.config.Tow-Boot.outputs.firmware}/config/noenv.config $out/config/noenv.rpi3.config
+          cp -v ${raspberryPi-3.config.Tow-Boot.outputs.firmware}/diff/noenv.build.diff $out/diff/noenv.rpi3.diff
 
           cp -v ${raspberryPi-4.config.Tow-Boot.outputs.firmware}/binaries/Tow-Boot.noenv.bin $out/binaries/Tow-Boot.noenv.rpi4.bin
           cp -v ${raspberryPi-4.config.Tow-Boot.outputs.firmware}/config/noenv.config $out/config/noenv.rpi4.config
+          cp -v ${raspberryPi-4.config.Tow-Boot.outputs.firmware}/diff/noenv.build.diff $out/diff/noenv.rpi4.diff
           )
         ''
       ) { }

--- a/boards/raspberryPi-aarch64/default.nix
+++ b/boards/raspberryPi-aarch64/default.nix
@@ -85,10 +85,12 @@ in
           mkdir -p $out/{binaries,config,diff}
           cp -v ${raspberryPi-3.config.Tow-Boot.outputs.firmware}/binaries/Tow-Boot.noenv.bin $out/binaries/Tow-Boot.noenv.rpi3.bin
           cp -v ${raspberryPi-3.config.Tow-Boot.outputs.firmware}/config/noenv.config $out/config/noenv.rpi3.config
+          cp -v ${raspberryPi-3.config.Tow-Boot.outputs.firmware}/config/noenv.newdefconfig $out/config/noenv.rpi3.newdefconfig
           cp -v ${raspberryPi-3.config.Tow-Boot.outputs.firmware}/diff/noenv.build.diff $out/diff/noenv.rpi3.diff
 
           cp -v ${raspberryPi-4.config.Tow-Boot.outputs.firmware}/binaries/Tow-Boot.noenv.bin $out/binaries/Tow-Boot.noenv.rpi4.bin
           cp -v ${raspberryPi-4.config.Tow-Boot.outputs.firmware}/config/noenv.config $out/config/noenv.rpi4.config
+          cp -v ${raspberryPi-4.config.Tow-Boot.outputs.firmware}/config/noenv.newdefconfig $out/config/noenv.rpi4.newdefconfig
           cp -v ${raspberryPi-4.config.Tow-Boot.outputs.firmware}/diff/noenv.build.diff $out/diff/noenv.rpi4.diff
           )
         ''

--- a/modules/build.nix
+++ b/modules/build.nix
@@ -92,18 +92,21 @@ in
         runCommand "Tow-Boot.${config.device.identifier}.${config.build.default.version}" {
           inherit (firmware) version;
         } ''
-          mkdir -p $out/{binaries,config}
+          mkdir -p $out/{binaries,config,diff}
           cp -rt $out/binaries/ ${firmware}/binaries/*
           cp -rt $out/config/ ${firmware}/config/*
+          cp -rt $out/diff/ ${firmware}/diff/*
           cp ${sharedDiskImage} $out/shared.disk-image.img
           ${optionalString (firmwareMMCBoot != null) ''
             cp -rt $out/binaries/ ${firmwareMMCBoot}/binaries/*
             cp -rt $out/config/ ${firmwareMMCBoot}/config/*
+            cp -rt $out/diff/ ${firmwareMMCBoot}/diff/*
             cp ${mmcBootInstallerImage} $out/mmcboot.installer.img
           ''}
           ${optionalString (firmwareSPI != null) ''
             cp -rt $out/binaries/ ${firmwareSPI}/binaries/*
             cp -rt $out/config/ ${firmwareSPI}/config/*
+            cp -rt $out/diff/ ${firmwareSPI}/diff/*
             cp ${spiInstallerImage} $out/spi.installer.img
           ''}
         ''

--- a/modules/tow-boot/builder.nix
+++ b/modules/tow-boot/builder.nix
@@ -200,11 +200,21 @@ in
 
           installPhase = ''
             runHook preInstall
-            mkdir -p $out
-            mkdir -p $out/config
-            cp .config $out/config/$variant.config
+
+            mkdir -vp $out
+            mkdir -vp $out/config
+
+            echo ":: Copying config files"
+            make $makeFlags "''${makeFlagsArray[@]}" savedefconfig
+
+            cp -v .config $out/config/$variant.config
+            cp -v defconfig $out/config/$variant.newdefconfig
+            cp -v "configs/${defconfig}" $out/config/$variant.defconfig
+
+            echo ":: Copying output binaries"
             mkdir -p $out/binaries
             ${installPhase}
+
             if test -e $out/binaries; then
               (
               echo ":: Adding uSWID data"

--- a/modules/tow-boot/config.nix
+++ b/modules/tow-boot/config.nix
@@ -64,6 +64,9 @@ in
         )
       ;
 
+      # Normalize baud rate across all platforms
+      BAUDRATE = freeform "115200";
+
       # And this ends up causing the menu to be used on ESCAPE (or CTRL+C)
       AUTOBOOT_USE_MENUKEY = yes;
 


### PR DESCRIPTION
This serves two purposes:

 - Get back to better compliance with providing the "actual" source
 - Help out developers understanding the build outputs

The compliance thing is simple: `diff` the `src` input from what is actually built. So any patches or edits made to the source tree after the fact are known. This will not `diff` Tow-Boot against U-Boot, only what is mechanically done during the build (except the Nix store path changes).

Developers are helped with the `defconfig` in use being copied **and** the "as built" `defconfig` being copied to the output. The first one is the `defconfig` file from the source, and the latter is what `make savedefconfig` produces after having forced the Nix-based options into the build.

* * *

(Builds on top of #311 to prevent merge conflicts...)