### PR TITLE
Improve generic U-Boot support

### DIFF
--- a/boards/uBoot-sandbox/default.nix
+++ b/boards/uBoot-sandbox/default.nix
@@ -1,5 +1,17 @@
 { config, lib, pkgs, ... }:
 
+let
+  inherit (lib)
+    mkForce
+    mkIf
+    versionAtLeast
+    versionOlder
+  ;
+
+  inherit (config.Tow-Boot)
+    uBootVersion
+  ;
+in
 {
   device = {
     manufacturer = "U-Boot";
@@ -26,7 +38,7 @@
         SANDBOX_RAM_SIZE_MB = freeform "512";
       })
       (helpers: with helpers; {
-        BOOTSTD = lib.mkForce yes;
+        BOOTSTD = mkIf (versionAtLeast uBootVersion "2022.07") (mkForce yes);
       })
     ];
     builder = {

--- a/modules/build.nix
+++ b/modules/build.nix
@@ -89,7 +89,7 @@ in
         let
           inherit (lib) optionalString;
         in
-        runCommand "Tow-Boot.${config.device.identifier}.${config.build.default.version}" {
+        runCommand "${config.Tow-Boot.outputName}.${config.device.identifier}.${config.build.default.version}" {
           inherit (firmware) version;
         } ''
           mkdir -p $out/{binaries,config,diff}

--- a/modules/build.nix
+++ b/modules/build.nix
@@ -92,6 +92,7 @@ in
         runCommand "${config.Tow-Boot.outputName}.${config.device.identifier}.${config.build.default.version}" {
           inherit (firmware) version;
         } ''
+          (PS4=" $ "; set -x
           mkdir -p $out/{binaries,config,diff}
           cp -rt $out/binaries/ ${firmware}/binaries/*
           cp -rt $out/config/ ${firmware}/config/*
@@ -109,6 +110,7 @@ in
             cp -rt $out/diff/ ${firmwareSPI}/diff/*
             cp ${spiInstallerImage} $out/spi.installer.img
           ''}
+          )
         ''
       ) {
         firmware = config.Tow-Boot.outputs.firmware;

--- a/modules/tow-boot/builder.nix
+++ b/modules/tow-boot/builder.nix
@@ -182,7 +182,7 @@ in
           hardeningDisable = [ "all" ];
 
           makeFlags = [
-            "DTC=dtc"
+            "DTC=${lib.getExe buildPackages.dtc}"
             "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
           ] ++ makeFlags;
 

--- a/modules/tow-boot/phone-ux.nix
+++ b/modules/tow-boot/phone-ux.nix
@@ -7,6 +7,7 @@
 let
   inherit (lib)
     escapeShellArg
+    mkForce
     mkIf
     mkMerge
     mkOption
@@ -153,6 +154,9 @@ in
   };
 
   config = mkMerge [
+    {
+      Tow-Boot.phone-ux.enable = mkIf config.Tow-Boot.buildUBoot (mkForce false);
+    }
     (mkIf (cfg.enable) {
       Tow-Boot = {
         inherit setup_leds;

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -75,6 +75,7 @@ in
           "2023.01" = "sha256-aUI7rTgPiaCRZjbonm3L0uRRLVhDCNki0QOdHkMxlQ8=";
           "2023.04" = "sha256-4xyskVRf9BtxzsXYwir9aVZFzW4qRCzNrKzWBTQGk0E=";
           "2023.07" = "sha256-EukhtGaucxzbw1Xmgyt/IryQsBrs7vmIb5iquns5QwA=";
+          "2023.10" = "sha256-4A5sbwFOBGEBc50I0G8yiBHOvPWuEBNI9AnLvVXOaQA=";
         };
         Tow-Boot = {
           "tb-2023.07-007" = "sha256-qEVvvnKy3fdFmU7Qn1U2PMqhf8p228v6+4XtkVGgQgk=";

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -76,6 +76,7 @@ in
           "2023.04" = "sha256-4xyskVRf9BtxzsXYwir9aVZFzW4qRCzNrKzWBTQGk0E=";
           "2023.07" = "sha256-EukhtGaucxzbw1Xmgyt/IryQsBrs7vmIb5iquns5QwA=";
           "2023.10" = "sha256-4A5sbwFOBGEBc50I0G8yiBHOvPWuEBNI9AnLvVXOaQA=";
+          "2024.01" = "sha256-uZYR8e0je/NUG9yENLaMlqbgWWcGH5kkQ8swqr6+9bM=";
         };
         Tow-Boot = {
           "tb-2023.07-007" = "sha256-qEVvvnKy3fdFmU7Qn1U2PMqhf8p228v6+4XtkVGgQgk=";

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -77,6 +77,7 @@ in
           "2023.07" = "sha256-EukhtGaucxzbw1Xmgyt/IryQsBrs7vmIb5iquns5QwA=";
           "2023.10" = "sha256-4A5sbwFOBGEBc50I0G8yiBHOvPWuEBNI9AnLvVXOaQA=";
           "2024.01" = "sha256-uZYR8e0je/NUG9yENLaMlqbgWWcGH5kkQ8swqr6+9bM=";
+          "2024.04" = "sha256-GKhT/jn6160DqQzC1Cda6u1tppc13vrDSSuAUIhD3Uo=";
         };
         Tow-Boot = {
           "tb-2023.07-007" = "sha256-qEVvvnKy3fdFmU7Qn1U2PMqhf8p228v6+4XtkVGgQgk=";

--- a/support/nix/eval-kconfig.nix
+++ b/support/nix/eval-kconfig.nix
@@ -45,6 +45,10 @@
 
           validatorSnippet = writeShellScript "kernel-configuration-validator-snippet" ''
             (
+            # This can be executed outside of a Nix build script.
+            set -eu
+            set -o pipefail
+
             echo
             echo ":: Validating kernel configuration"
             echo


### PR DESCRIPTION
With these changes, more care is taken to have all devices buildable with stock U-Boot.

There is no SLA around this, at this point in time. It's still intended to help with testing where issues come from.

The device-specific changes here are meant to ensure they build.

This is also phase 1 of updating the base U-Boot version: checking that U-Boot builds.

* * *

Builds on top of #312.