### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ concurrency:
 jobs:
   generate-devices-matrix:
     name: Generate devices matrix
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: DeterminateSystems/nix-installer-action@v4
+      - uses: DeterminateSystems/nix-installer-action@main
       - id: devices-matrix
         run: printf "matrix=%s" "$(nix-instantiate --json --eval .ci/devices-list.nix)" >> $GITHUB_OUTPUT
     outputs:
@@ -25,16 +25,16 @@ jobs:
   build-all-devices:
     name: "Build: ${{ matrix.device }}"
     needs: generate-devices-matrix
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         device: ${{ fromJson(needs.generate-devices-matrix.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: DeterminateSystems/nix-installer-action@v4
-      - uses: DeterminateSystems/magic-nix-cache-action@v2
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Build archive (release)
         if: "startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request'"
         run: |
@@ -51,26 +51,26 @@ jobs:
           archive=$(readlink -f result)
           cp --dereference "$archive" "${archive#*-}"
       - name: Upload archive to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: '*.tar.xz'
           if-no-files-found: error
 
   docs:
     name: Build docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: DeterminateSystems/nix-installer-action@v4
+      - uses: DeterminateSystems/nix-installer-action@main
       - run: nix-build doc/ -A archive
       - name: Rename archive
         run: |
           archive=$(readlink -f result)
           cp --dereference "$archive" "${archive#*-}"
       - name: Upload archive to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: '*.tar.xz'
           if-no-files-found: error
@@ -79,7 +79,7 @@ jobs:
     name: Release
     if: startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request'
     needs: [build-all-devices, docs]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Download archives from Artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Upload archive to Artifacts
         uses: actions/upload-artifact@v4
         with:
+          name: "artifact-${{ matrix.device }}"
           path: '*.tar.xz'
           if-no-files-found: error
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Upload archive to Artifacts
         uses: actions/upload-artifact@v4
         with:
+          name: "artifact-docs"
           path: '*.tar.xz'
           if-no-files-found: error
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,15 +7,15 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: DeterminateSystems/nix-installer-action@v4
       - run: nix-build doc/
       - if: success()
-        uses: crazy-max/ghaction-github-pages@v2
+        uses: crazy-max/ghaction-github-pages@v4
         with:
           target_branch: gh-pages
           build_dir: result/


### PR DESCRIPTION
this fixes all the warnings from outdated node modules ad duplicate artifact names.

I tried the artifact on my pinebook pro and the spi installer started fine but after that it no longer booted and i had to unscrew the cover to short the spi flash so it booted from the sd card again.

keeping this as a draft because it bricked my pinebook