### PR TITLE
docker/build: Fix `Permission denied` error when building with Docker shim on MacOS

### DIFF
--- a/support/docker/build.sh
+++ b/support/docker/build.sh
@@ -74,7 +74,7 @@ if [ -e /Tow-Boot ]; then
 		cp -r "$target" "$proxy_dir/$f"
 		chmod -R u+w "$proxy_dir/$f"
 
-		cp -r "$proxy_dir/$f" "$current_dir/$f"
+		mv "$proxy_dir/$f" "$current_dir/$f"
 		chown -R "$REAL_UID:$REAL_GID" "$current_dir/$f"
 	done
 else


### PR DESCRIPTION
With Docker on Mac `cp -R` fails to copy anything into `result` directory after creating it without write permissions.
This change makes a build result copy within container and adds write permissions to the files inside, before writing them into the `/Tow-Boot/` directory.

Please try building with shim on Linux/Windows

Fixes #339