### PR TITLE
Backport PINE64 PineTab (A64) to 2023.07-007 (#341)

### DIFF
--- a/boards/pine64-pinetabA64/INSTALLING.md
+++ b/boards/pine64-pinetabA64/INSTALLING.md
@@ -13,19 +13,15 @@ SD card.
 # dd if=mmcboot.installer.img of=/dev/XXX bs=1M oflag=direct,sync status=progress
 ```
 
-Once done, power-off your *Pinetab (A64)*, remove its battery, and insert the
+Once done, power-off your *Pinetab (A64)* and insert the
 SD card in the SD card slot.
 
-Put back the battery in the *Pinetab (A64)*, and power it on.
+Power it on.
 
 > Unless you know the battery is completely charged, it is recommended to
-> connect the phone to a power source. Just in case.
+> connect the tablet to a power source. Just in case.
 
-When starting up with Tow-Boot, which the installer image use, the phone will
-vibrate slightly and the LED will turn red. After a short moment, the LED
-should turn yellow.
-
-A few moments later the display will turn on with a blue colour, or will
+When starting up with Tow-Boot, which the installer image use, the display will turn on with a blue colour, or will
 directly boot to the installer GUI.
 
 In the installer GUI, select *“Install Tow-Boot to eMMC Boot”*. It is not

--- a/boards/pine64-pinetabA64/INSTALLING.md
+++ b/boards/pine64-pinetabA64/INSTALLING.md
@@ -1,0 +1,47 @@
+## Installation instructions
+
+### Installing to eMMC Boot (recommended)
+
+By installing Tow-Boot to eMMC Boot, your *PINE64 Pinetab (A64)* will be able
+to start using standards-based booting without conflicting with the
+operating system storage.
+
+To do so, you will need to write the eMMC Boot installer image to a suitable
+SD card.
+
+```
+# dd if=mmcboot.installer.img of=/dev/XXX bs=1M oflag=direct,sync status=progress
+```
+
+Once done, power-off your *Pinetab (A64)*, remove its battery, and insert the
+SD card in the SD card slot.
+
+Put back the battery in the *Pinetab (A64)*, and power it on.
+
+> Unless you know the battery is completely charged, it is recommended to
+> connect the phone to a power source. Just in case.
+
+When starting up with Tow-Boot, which the installer image use, the phone will
+vibrate slightly and the LED will turn red. After a short moment, the LED
+should turn yellow.
+
+A few moments later the display will turn on with a blue colour, or will
+directly boot to the installer GUI.
+
+In the installer GUI, select *“Install Tow-Boot to eMMC Boot”*. It is not
+necessary to erase the storage before installing. Erasing the storage can be
+used to uninstall Tow-Boot (or any other platform firmware installed to the
+eMMC Boot partition).
+
+Once installed, remove the installation media, and verify Tow-Boot starts from
+power-on.
+
+
+### Installing to shared storage
+
+Using the shared storage strategy on the *Pinetab (A64)* can be done by
+writing the `shared.disk-image.img` to an SD card or directly to eMMC.
+
+```
+ # dd if=shared.disk-image.img of=/dev/XXX bs=1M oflag=direct,sync status=progress
+```

--- a/boards/pine64-pinetabA64/README.md
+++ b/boards/pine64-pinetabA64/README.md
@@ -1,0 +1,50 @@
+# PINE64 Pinetab (A64)
+
+## Device-specific notes
+
+There is no display output for this device.
+
+
+## Startup order conflicts
+
+The Allwinner SoC used in the Pinetab (A64) will always prefer starting
+the platform firmware (U-Boot) from SD card when available.
+
+When using some pre-built distribution images, it may be desirable to neuter
+the U-Boot that is baked into the image.
+
+With the usual U-Boot setup for Allwinner, the easiest way to strip U-Boot
+from an eMMC or SD image is by running the following command, taking care
+to replace `[DEVICE]` with the device for the storage device.
+
+```
+ $ sudo dd if=/dev/zero of=/dev/[DEVICE] bs=8k seek=1 count=4
+```
+
+When running the command on the Pinetab (A64), *usually* the block device
+for the SD card is `mmcblk0`, and the block device for the eMMC is `mmcblk2`.
+You can use `lsblk` to look at the block devices available.
+
+> **NOTE**: Make sure the operating system image has a baked-in U-Boot
+> install before issuing the command, and that you are targeting the right
+> storage device.
+>
+> Some distributions target UEFI boot, and use GPT. Issuing this command
+> **will break the partition table**.
+
+Finally, on distributions shipping U-Boot, it is prudent to disable the
+package that provides the automatic upgrade facilities.
+
+ - For Manjaro and Arch Linux, the package is called `uboot-pinetab`.
+
+
+## Additional features
+
+The phone can be started in *USB Mass Storage* mode by holding the *volume up*
+button at startup before and during the second vibration. The LED will turn
+blue if done successfully. In this mode, the phone will work like a USB drive
+when connected to a host computer.
+
+Booting an operating system from an SD card will require holding the *volume
+down* button before and during the second vibration. When done successfully,
+the LED will turn aqua.

--- a/boards/pine64-pinetabA64/README.md
+++ b/boards/pine64-pinetabA64/README.md
@@ -1,4 +1,4 @@
-# PINE64 Pinetab (A64)
+# PINE64 PineTab (A64)
 
 ## Device-specific notes
 
@@ -40,11 +40,9 @@ package that provides the automatic upgrade facilities.
 
 ## Additional features
 
-The phone can be started in *USB Mass Storage* mode by holding the *volume up*
-button at startup before and during the second vibration. The LED will turn
-blue if done successfully. In this mode, the phone will work like a USB drive
+The tablet can be started in *USB Mass Storage* mode by holding the *volume up*
+button at startup. In this mode, the tablet will work like a USB drive
 when connected to a host computer.
 
 Booting an operating system from an SD card will require holding the *volume
-down* button before and during the second vibration. When done successfully,
-the LED will turn aqua.
+down* button.

--- a/boards/pine64-pinetabA64/default.nix
+++ b/boards/pine64-pinetabA64/default.nix
@@ -1,0 +1,55 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkMerge
+    mkIf
+  ;
+  inherit (config.Tow-Boot) buildUBoot;
+in
+{
+  device = {
+    manufacturer = "PINE64";
+    name = "PineTab (A64)";
+    identifier = "pine64-pinetabA64";
+    productPageURL = "https://www.pine64.org/pinetab/";
+    supportLevel = "supported";
+  };
+
+  hardware = {
+    soc = "allwinner-a64";
+    mmcBootIndex = "1";
+  };
+
+  Tow-Boot = {
+    defconfig = "pinetab_defconfig";
+    phone-ux = {
+      enable = true;
+      blind = true;
+      wip = {
+        led_R = "led-2";
+        led_G = "led-1";
+        led_B = "led-0";
+        mmcSD   = "0";
+        mmcEMMC = "1";
+      };
+    };
+    config = mkMerge [
+      [(helpers: with helpers; {
+        USB_MUSB_GADGET = yes;
+        USB_GADGET_MANUFACTURER = freeform ''"Pine64"'';
+      })]
+      # Requires Tow-Boot patches
+      (mkIf (!buildUBoot) [(helpers: with helpers;{
+        BUTTON_GPIO = yes;
+        BUTTON_SUN4I_LRADC = yes;
+        LED_GPIO = yes;
+        VIBRATOR_GPIO = yes;
+      })])
+    ];
+    touch-installer = {
+      targetBlockDevice = "/dev/mmcblk2boot0";
+    };
+  };
+  documentation.sections.installationInstructions = builtins.readFile ./INSTALLING.md;
+}

--- a/embedded-linux-os/devices/pine64-pinetabA64/default.nix
+++ b/embedded-linux-os/devices/pine64-pinetabA64/default.nix
@@ -1,0 +1,359 @@
+{ config, lib, pkgs, ... }:
+
+{
+  device = {
+    name = "pine64/pinetab";
+    dtbFiles = [
+      "allwinner/sun50i-a64-pinetab.dtb"
+    ];
+  };
+
+  hardware = {
+    cpu = "allwinner-a64";
+  };
+
+  wip.kernel.package = pkgs.callPackage ./kernel {};
+  wip.kernel.defconfig = pkgs.writeText "empty" "";
+
+  boot.cmdline = [
+    "console=ttyS0,115200n8"
+    "earlycon=uart,mmio32,0x01c28000"
+  ];
+
+  wip.kernel = {
+    structuredConfig = lib.mkMerge [
+      # Slim down config somewhat
+      # TODO: move into more general options
+      (with lib.kernel; {
+        NETFILTER = no;
+        BPFILTER = no;
+        USB_NET_DRIVERS = no;
+        WIRELESS = no;
+        WIREGUARD = no;
+        BT = no;
+        WLAN = no;
+        NETDEVICES = no;
+        INET = no; # No TCP/IP networking
+        ETHTOOL_NETLINK = no;
+        SERIO = no;
+        LEGACY_PTYS = no;
+        EFI = no;
+        HW_RANDOM = no;
+        HWMON = no;
+      })
+
+      (with lib.kernel; {
+        SYSVIPC = yes;
+        POSIX_MQUEUE = yes;
+        NO_HZ = yes;
+        HIGH_RES_TIMERS = yes;
+        PREEMPT_VOLUNTARY = yes;
+
+        # XXX move into celun as an option for "tiny"
+        CC_OPTIMIZE_FOR_SIZE = yes;
+
+        ARCH_SUNXI = yes;
+        NR_CPUS = freeform "4";
+        COMPAT = yes;
+
+        ARCH_RANDOM = no;
+        ARM64_AMU_EXTN = no;
+        ARM64_BTI = no;
+        ARM64_CNP = no;
+        ARM64_E0PD = no;
+        ARM64_ERRATUM_1024718 = no;
+        ARM64_ERRATUM_1165522 = no;
+        ARM64_ERRATUM_1286807 = no;
+        ARM64_ERRATUM_1319367 = no;
+        ARM64_ERRATUM_1418040 = no;
+        ARM64_ERRATUM_1463225 = no;
+        ARM64_ERRATUM_1530923 = no;
+        ARM64_ERRATUM_1542419 = no;
+        ARM64_ERRATUM_832075 = no;
+        ARM64_ERRATUM_858921 = no;
+        ARM64_HW_AFDBM = no;
+        ARM64_PAN = no;
+        ARM64_PTR_AUTH = no;
+        ARM64_RAS_EXTN = no;
+        ARM64_SVE = no;
+        ARM64_USE_LSE_ATOMICS = no;
+        CAVIUM_ERRATUM_22375 = no;
+        CAVIUM_ERRATUM_23154 = no;
+        CAVIUM_ERRATUM_27456 = no;
+        CAVIUM_ERRATUM_30115 = no;
+        CAVIUM_TX2_ERRATUM_219 = no;
+        FUJITSU_ERRATUM_010001 = no;
+        HISILICON_ERRATUM_161010101 = no;
+        HISILICON_ERRATUM_161600802 = no;
+        QCOM_FALKOR_ERRATUM_1003 = no;
+        QCOM_FALKOR_ERRATUM_1009 = no;
+        QCOM_FALKOR_ERRATUM_E1041 = no;
+        QCOM_QDF2400_ERRATUM_0065 = no;
+        SOCIONEXT_SYNQUACER_PREITS = no;
+
+        ENERGY_MODEL = yes;
+        CPU_IDLE = yes;
+        CPU_IDLE_GOV_LADDER = yes;
+        ARM_CPUIDLE = yes;
+        ARM_PSCI_CPUIDLE = yes;
+
+        CPU_FREQ = yes;
+        CPU_FREQ_STAT = yes;
+        CPU_FREQ_DEFAULT_GOV_POWERSAVE = yes;
+        CPU_FREQ_GOV_POWERSAVE = yes;
+        CPU_FREQ_GOV_USERSPACE = yes;
+        CPU_FREQ_GOV_ONDEMAND = yes;
+        CPU_FREQ_GOV_CONSERVATIVE = yes;
+        CPU_FREQ_GOV_SCHEDUTIL = yes;
+        CPUFREQ_DT = yes;
+
+        JUMP_LABEL = yes;
+        STACKPROTECTOR = no;
+        GCC_PLUGINS = no;
+
+        CMA = yes;
+        CMA_DEBUGFS = yes;
+
+        ZPOOL = yes;
+        ZBUD = yes;
+        Z3FOLD = yes;
+        ZSMALLOC = yes;
+
+        NET = yes;
+        PACKET = yes;
+        PACKET_DIAG = yes;
+        UNIX = yes;
+        UNIX_DIAG = yes;
+
+        WIRELESS = no;
+        RFKILL = yes;
+        RFKILL_GPIO = yes;
+
+        ARM_SCPI_PROTOCOL = yes;
+        ARM_SMCCC_SOC_ID = no;
+
+        INPUT_MOUSEDEV = yes;
+        INPUT_MOUSEDEV_PSAUX = yes;
+        INPUT_EVDEV = yes;
+
+        KEYBOARD_GPIO = yes;
+        KEYBOARD_GPIO_POLLED = yes;
+        KEYBOARD_SUN4I_LRADC = yes;
+
+        INPUT_TOUCHSCREEN = yes;
+        TOUCHSCREEN_GOODIX = yes;
+
+        INPUT_MISC = yes;
+        INPUT_AXP20X_PEK = yes;
+
+        INPUT_GPIO_VIBRA = yes;
+
+        SERIAL_8250 = yes;
+        SERIAL_8250_DEPRECATED_OPTIONS = no;
+        SERIAL_8250_CONSOLE = yes;
+        SERIAL_8250_NR_UARTS = freeform "8";
+        SERIAL_8250_RUNTIME_UARTS = freeform "8";
+        SERIAL_8250_DW = yes;
+        SERIAL_OF_PLATFORM = yes;
+        SERIAL_DEV_BUS = yes;
+
+        I2C_CHARDEV = yes;
+        I2C_GPIO = yes;
+        I2C_MV64XXX = yes;
+
+        PINCTRL_AXP209 = yes;
+        PINCTRL_SINGLE = yes;
+        PINCTRL_SUN8I_H3_R = no;
+        PINCTRL_SUN50I_H5 = no;
+        PINCTRL_SUN50I_H6 = no;
+        PINCTRL_SUN50I_H6_R = no;
+        PINCTRL_SUN50I_H616 = no;
+        PINCTRL_SUN50I_H616_R = no;
+
+        NVMEM_REBOOT_MODE = yes;
+
+        CHARGER_AXP20X = yes;
+        BATTERY_AXP20X = yes;
+        AXP20X_POWER = yes;
+
+        THERMAL = yes;
+        THERMAL_STATISTICS = yes;
+        THERMAL_WRITABLE_TRIPS = yes;
+        THERMAL_GOV_FAIR_SHARE = yes;
+        THERMAL_GOV_BANG_BANG = yes;
+        CPU_THERMAL = yes;
+        SUN8I_THERMAL = yes;
+
+        WATCHDOG = yes;
+        SUNXI_WATCHDOG = yes;
+
+        MFD_SUN4I_GPADC = yes;
+        MFD_AXP20X_RSB = yes;
+        MFD_SYSCON = yes;
+
+        REGULATOR = yes;
+        REGULATOR_FIXED_VOLTAGE = yes;
+        REGULATOR_AXP20X = yes;
+        REGULATOR_GPIO = yes;
+
+        DRM = yes;
+        DRM_LOAD_EDID_FIRMWARE = no;
+        DRM_SUN4I = yes;
+        DRM_SUN4I_HDMI = no;
+        DRM_SUN4I_BACKEND = no;
+        DRM_SUN6I_DSI = yes;
+        DRM_SUN8I_DW_HDMI = yes; # Needed even if we don't use HDMI
+        DRM_SUN8I_MIXER = yes;
+        DRM_PANEL_ILITEK_ILI9881C = yes;
+        DRM_PANEL_SITRONIX_ST7703 = yes;
+        DRM_DW_HDMI_CEC = yes;
+        DRM_LIMA = yes;
+        FB = yes;
+        FB_SIMPLE = yes;
+        BACKLIGHT_CLASS_DEVICE = yes;
+        BACKLIGHT_PWM = yes;
+        FRAMEBUFFER_CONSOLE_ROTATION = yes;
+
+        #LOGO = yes;
+        LOGO = no; # XXX
+
+        MMC = yes;
+        MMC_SUNXI = yes;
+
+        NEW_LEDS = yes;
+        LEDS_CLASS = yes;
+        LEDS_GPIO = yes;
+
+        RTC_CLASS = yes;
+        RTC_INTF_PROC = no;
+        RTC_DRV_SUN6I = yes;
+
+        DMADEVICES = yes;
+        DMA_SUN6I = yes;
+        DMABUF_HEAPS = yes;
+        DMABUF_HEAPS_SYSTEM = yes;
+        DMABUF_HEAPS_CMA = yes;
+
+        CLK_SUNXI_PRCM_SUN9I = no;
+        SUN50I_H6_CCU = no;
+        SUN50I_H616_CCU = no;
+        SUN50I_H6_R_CCU = no;
+        SUN8I_H3_CCU = no;
+
+        MAILBOX = yes;
+        IOMMU_SUPPORT = yes;
+        IOMMU_IO_PGTABLE_LPAE = yes;
+
+        DEVFREQ_GOV_PERFORMANCE = yes;
+        DEVFREQ_GOV_POWERSAVE = yes;
+        DEVFREQ_GOV_USERSPACE = yes;
+        DEVFREQ_GOV_PASSIVE = yes;
+        PM_DEVFREQ_EVENT = yes;
+
+        IIO = yes;
+        IIO_BUFFER_CB = yes;
+        IIO_BUFFER_HW_CONSUMER = yes;
+        IIO_SW_DEVICE = yes;
+        IIO_SW_TRIGGER = yes;
+
+        AXP20X_ADC = yes;
+
+        INV_MPU6050_I2C = yes;
+        STK3310 = yes;
+        IIO_ST_MAGN_3AXIS = yes;
+        IIO_HRTIMER_TRIGGER = yes;
+        IIO_INTERRUPT_TRIGGER = yes;
+        IIO_SYSFS_TRIGGER = yes;
+
+        PWM = yes;
+        PWM_SUN4I = yes;
+
+        ARM_CCI5xx_PMU = no;
+        NVMEM_SUNXI_SID = yes;
+
+        DMA_CMA = yes;
+        CMA_SIZE_MBYTES = freeform "64";
+
+        CONSOLE_LOGLEVEL_DEFAULT = freeform "3";
+
+        FRAME_WARN = freeform "1024";
+
+        MAGIC_SYSRQ = yes;
+
+        DEBUG_FS = yes;
+
+        STACKTRACE = yes;
+      })
+
+
+      # Disabling generally unneeded things
+      (with lib.kernel; {
+        MEDIA_SUBDRV_AUTOSELECT = no;
+        NETWORK_FILESYSTEMS = no;
+        RAID6_PQ_BENCHMARK = no;
+        RUNTIME_TESTING_MENU = no;
+        STRICT_DEVMEM = no;
+        VHOST_MENU = no;
+        VIRTIO_MENU = no;
+
+        HID_A4TECH = no;
+        HID_APPLE = no;
+        HID_BELKIN = no;
+        HID_CHERRY = no;
+        HID_CHICONY = no;
+        HID_CYPRESS = no;
+        HID_EZKEY = no;
+        HID_ITE = no;
+        HID_KENSINGTON = no;
+        HID_LOGITECH = no;
+        HID_REDRAGON = no;
+        HID_MICROSOFT = no;
+        HID_MONTEREY = no;
+        INPUT_MOUSE = no;
+        KEYBOARD_ATKBD = no;
+      })
+
+      (with lib.kernel; {
+        EXPERT = no;
+        EMBEDDED = no;
+      })
+
+      # USB
+      (with lib.kernel; {
+        USB_HIDDEV = yes;
+        USB = yes;
+        USB_OTG = yes;
+        USB_OTG_FSM = yes;
+        USB_MON = yes;
+        USB_EHCI_HCD = yes;
+        USB_EHCI_HCD_PLATFORM = yes;
+        USB_OHCI_HCD = yes;
+        USB_OHCI_HCD_PLATFORM = yes;
+        USB_ACM = yes;
+        USBIP_CORE = yes;
+        USBIP_VHCI_HCD = yes;
+        USBIP_HOST = yes;
+        USB_MUSB_HDRC = yes;
+        USB_MUSB_SUNXI = yes;
+        MUSB_PIO_ONLY = yes;
+        USB_SERIAL = yes;
+        USB_SERIAL_SIMPLE = yes;
+        USB_SERIAL_CH341 = yes;
+        USB_SERIAL_CP210X = yes;
+        USB_SERIAL_FTDI_SIO = yes;
+        USB_SERIAL_QCAUX = yes;
+        USB_SERIAL_QUALCOMM = yes;
+        USB_SERIAL_OPTION = yes;
+        NOP_USB_XCEIV = yes;
+
+        PHY_SUN4I_USB = yes;
+
+        TYPEC = yes;
+        TYPEC_TCPM = yes;
+        TYPEC_TCPCI = yes;
+        TYPEC_UCSI = yes;
+        TYPEC_DP_ALTMODE = yes;
+      })
+    ];
+  };
+}

--- a/embedded-linux-os/devices/pine64-pinetabA64/kernel/default.nix
+++ b/embedded-linux-os/devices/pine64-pinetabA64/kernel/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchFromGitHub, fetchpatch }:
+
+# This is not actually the build derivation...
+# We're co-opting this derivation as a source of truth for the version and src.
+stdenv.mkDerivation rec {
+  version = "5.15.0";
+
+  src = fetchFromGitHub {
+    owner = "torvalds"; # Originally megous
+    repo = "linux";
+    rev = "8bb7eca972ad531c9b149c0a51ab43a417385813";
+    sha256 = "Ou2HOUI1sR8z03LiHAqEgOlUCOXG0yF6/Wbv+2LIWZs=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://salsa.debian.org/Mobian-team/devices/kernels/sunxi64-linux/-/raw/mobian-5.15/debian/patches/pinetab/0209-arm64-allwinner-dts-a64-enable-K101-IM2BYL02-panel-f.patch";
+      sha256 = "sha256-+hfPX5uSEjpJ/oM7HMzoXNBMJtqHvK7bJA2KwhROv70=";
+    })
+  ];
+}


### PR DESCRIPTION
This will be tagged `release-2023.07-007.pine64-pinetabA64`, and will not constitute a new release.

The tag will serve to provide the built artifact from the release GitHub actions.