### PR TITLE
Reduce impact of FOD and hashes pitfalls in Tow-Boot

### DIFF
--- a/boards/radxa-zero2/default.nix
+++ b/boards/radxa-zero2/default.nix
@@ -3,7 +3,7 @@
 let
   # TODO: remove once imported in the LibreELEC FIP frmware packages
   #       alternatively reconsider how we handle vendor-provided blobs?
-  radxa-fip = pkgs.callPackage (
+  radxa-fip = pkgs.Tow-Boot.callPackage (
     { stdenv
     , lib
     , fetchFromGitHub

--- a/boards/radxa-zero2/default.nix
+++ b/boards/radxa-zero2/default.nix
@@ -17,7 +17,7 @@ let
         owner = "radxa";
         repo = "fip";
         rev = "4e7cacb68682bf2223974895d8e0d6368beac101";
-        sha256 = "sha256-QZ1tqQpnvWrYrkxik3S9dXa0+KqmsH8huFqkw2iyOBk=";
+        hash = "sha256-QZ1tqQpnvWrYrkxik3S9dXa0+KqmsH8huFqkw2iyOBk=";
       };
 
       installPhase = ''

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,12 @@
 , silent ? false
 , pkgs ? import ./nixpkgs.nix { }
 , src ? null
+, config ? null
 }:
+
+if !(builtins.isNull config)
+then throw "hint: use the `configuration` argument to provide a configuration fragment."
+else
 
 let
   release-tools = import ./support/nix/release-tools.nix { inherit pkgs; };

--- a/modules/hardware/rockchip/default.nix
+++ b/modules/hardware/rockchip/default.nix
@@ -1,9 +1,6 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (pkgs)
-    fetchpatch
-  ;
   inherit (lib)
     mkIf
     mkMerge

--- a/modules/tow-boot/builder.nix
+++ b/modules/tow-boot/builder.nix
@@ -79,7 +79,7 @@ in
   };
   config = {
     Tow-Boot = {
-      outputs.firmware = lib.mkDefault (pkgs.callPackage (
+      outputs.firmware = lib.mkDefault (pkgs.Tow-Boot.callPackage (
         { stdenv
         , lib
         , buildPackages

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -64,20 +64,20 @@ in
 
       knownHashes = {
         U-Boot = {
-          "2021.01" = "sha256-tAfhUQp06GO4tctCokYlNE8ODC/HWC2MhmvYmTZ9BFQ=";
-          "2021.04" = "sha256-DUOLG7XM61ehjqLeSg1R975bBbmHF98Fk4Y24Krf4Ro=";
-          "2021.07" = "sha256-MSt+6uRFgdE2LDo/AsKNgGZHdWyCuoxyJBx82+aLp34=";
-          "2021.10" = "1m0bvwv8r62s4wk4w3cmvs888dhv9gnfa98dczr4drk2jbhj7ryd";
-          "2022.01" = "sha256-gbRUMifbIowD+KG/XdvIE7C7j2VVzkYGTvchpvxoBBM=";
-          "2022.04" = "sha256-aOBlQTkmd44nbsOr0ouzL6gquqSmiY1XDB9I+9sIvNA=";
-          "2022.07" = "sha256-krCOtJwk2hTBrb9wpxro83zFPutCMOhZrYtnM9E9z14=";
-          "2022.10" = "sha256-ULRIKlBbwoG6hHDDmaPCbhReKbI1ALw1xQ3r1/pGvfg=";
-          "2023.01" = "sha256-aUI7rTgPiaCRZjbonm3L0uRRLVhDCNki0QOdHkMxlQ8=";
-          "2023.04" = "sha256-4xyskVRf9BtxzsXYwir9aVZFzW4qRCzNrKzWBTQGk0E=";
-          "2023.07" = "sha256-EukhtGaucxzbw1Xmgyt/IryQsBrs7vmIb5iquns5QwA=";
-          "2023.10" = "sha256-4A5sbwFOBGEBc50I0G8yiBHOvPWuEBNI9AnLvVXOaQA=";
-          "2024.01" = "sha256-uZYR8e0je/NUG9yENLaMlqbgWWcGH5kkQ8swqr6+9bM=";
-          "2024.04" = "sha256-GKhT/jn6160DqQzC1Cda6u1tppc13vrDSSuAUIhD3Uo=";
+          "2021.01" = "sha256-tI80LPNs8jY8Ir78VdHP0NOMZvjkgICWTE1dVUruVIg=";
+          "2021.04" = "sha256-QxrTPcx0n0NWUJ990EuIWyOBtknW/fHDRcrYP0yQzTo=";
+          "2021.07" = "sha256-e7sXjV+O1BFDtKAhU8kdAk2mWxPTGOvJ5RU3upMM1VM=";
+          "2021.10" = "sha256-2CcIHGbm0HPmY63Xsjaf/Yy78JbRPNhmvZmRJAyla2U=";
+          "2022.01" = "sha256-kKxo62/TI0HD8uZaL39FyJc783JsErkfspKsQ6uvEMU=";
+          "2022.04" = "sha256-iQNy28xMlixQJLc97hfOBwJ0bod1XYRjgIE1UhFslCw=";
+          "2022.07" = "sha256-1EONRmYLsD0uxo+kpE6mLIYkYMU09Yt0EvSbHhj5prw=";
+          "2022.10" = "sha256-L6AXbJEDx+KoMvqBuJYyIyK2Xn2zyF21NH5mMNvygmM=";
+          "2023.01" = "sha256-30fe8klLHRsEtEQ1VpYh4S+AflG5yCQYWlGmpWyFL8w=";
+          "2023.04" = "sha256-k4CgiG6rOdgex+YxMRXqyJF7NFqAN9R+UKc3Y/+7jV0=";
+          "2023.07" = "sha256-hd9ySV4uUczfigtwrupVlEs8JkK9yX44kaBJgDAykk4=";
+          "2023.10" = "sha256-f0xDGxTatRtCxwuDnmsqFLtYLIyjA5xzyQcwfOy3zEM=";
+          "2024.01" = "sha256-0Da7Czy9cpQ+D5EICc3/QSZhAdCBsmeMvBgykYhAQFw=";
+          "2024.04" = "sha256-IlaDdjKq/Pq2orzcU959h93WXRZfvKBGDO/MFw9mZMg=";
         };
         Tow-Boot = {
           "tb-2023.07-007" = "sha256-qEVvvnKy3fdFmU7Qn1U2PMqhf8p228v6+4XtkVGgQgk=";
@@ -86,7 +86,7 @@ in
 
       src = if config.Tow-Boot.buildUBoot then
         let knownHashes = config.Tow-Boot.knownHashes.U-Boot; in
-        mkDefault (pkgs.Tow-Boot.fetchurl {
+        mkDefault (pkgs.Tow-Boot.fetchzip {
           url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${uBootVersion}.tar.bz2";
           hash =
             if knownHashes ? ${uBootVersion}

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -88,7 +88,7 @@ in
         let knownHashes = config.Tow-Boot.knownHashes.U-Boot; in
         mkDefault (pkgs.Tow-Boot.fetchurl {
           url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${uBootVersion}.tar.bz2";
-          sha256 =
+          hash =
             if knownHashes ? ${uBootVersion}
             then knownHashes.${uBootVersion}
             else builtins.throw "No known hashes for upstream release U-Boot version ${uBootVersion}"
@@ -100,7 +100,7 @@ in
           repo = "U-Boot";
           owner = "Tow-Boot";
           rev = "${tag}";
-          sha256 =
+          hash =
             if knownHashes ? ${tag}
             then knownHashes.${tag}
             else builtins.throw "No known hashes for Tow-Boot-flavoured U-Boot matching tag ${tag}"

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -86,7 +86,7 @@ in
 
       src = if config.Tow-Boot.buildUBoot then
         let knownHashes = config.Tow-Boot.knownHashes.U-Boot; in
-        mkDefault (pkgs.fetchurl {
+        mkDefault (pkgs.Tow-Boot.fetchurl {
           url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${uBootVersion}.tar.bz2";
           sha256 =
             if knownHashes ? ${uBootVersion}
@@ -96,7 +96,7 @@ in
         })
       else
         let knownHashes = config.Tow-Boot.knownHashes.Tow-Boot; in
-        mkDefault (pkgs.fetchFromGitHub {
+        mkDefault (pkgs.Tow-Boot.fetchFromGitHub {
           repo = "U-Boot";
           owner = "Tow-Boot";
           rev = "${tag}";

--- a/modules/u-boot.nix
+++ b/modules/u-boot.nix
@@ -7,7 +7,7 @@ let
     versionOlder
     versionAtLeast
   ;
-  inherit (pkgs)
+  inherit (pkgs.Tow-Boot)
     fetchpatch
   ;
 

--- a/modules/u-boot.nix
+++ b/modules/u-boot.nix
@@ -16,10 +16,10 @@ let
   ;
 
   tbPatch =
-    rev: sha256:
+    rev: hash:
     fetchpatch {
       url = "https://github.com/Tow-Boot/U-Boot/commit/${rev}.patch";
-      inherit sha256;
+      inherit hash;
     }
   ;
 in
@@ -40,7 +40,7 @@ mkIf config.Tow-Boot.buildUBoot
     # common: Kconfig: Fix CMD_BMP/BMP dependency
     (fetchpatch {
       url = "https://patchwork.ozlabs.org/project/uboot/patch/20230709231810.633044-1-samuel@dionne-riel.com/raw/";
-      sha256 = "sha256-hBv2BeLjyUr4ydTieNv8AZ0FGXqwKHo+2+GyLGgodUQ=";
+      hash = "sha256-hBv2BeLjyUr4ydTieNv8AZ0FGXqwKHo+2+GyLGgodUQ=";
     })
   ]
   ;

--- a/support/image-builder/disk-image/partitioning-scheme/gpt/builder.nix
+++ b/support/image-builder/disk-image/partitioning-scheme/gpt/builder.nix
@@ -1,6 +1,5 @@
 { stdenvNoCC
 , lib
-, fetchpatch
 , gptfdisk
 , buildPackages
 , utillinux

--- a/support/image-builder/disk-image/partitioning-scheme/mbr/builder.nix
+++ b/support/image-builder/disk-image/partitioning-scheme/mbr/builder.nix
@@ -1,6 +1,5 @@
 { stdenvNoCC
 , lib
-, fetchpatch
 , buildPackages
 , utillinux
 , config

--- a/support/overlay/amlogic-firmware/default.nix
+++ b/support/overlay/amlogic-firmware/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     owner = "LibreELEC";
     repo = "amlogic-boot-fip";
     rev = "ac20772f44b2b74c8f55331b5c91a277d0bfbc37";
-    sha256 = "1z739644655w1wbfi3456qg9k1izrmn2xci6vjh4sb55cxydja15";
+    hash = "sha256-JSjZfGelLE2g3CayLmzNP4aZHjaFjOgWD7wUQ4hJ4/w=";
   };
 
   installPhase = ''

--- a/support/overlay/arm-trusted-firmware/default.nix
+++ b/support/overlay/arm-trusted-firmware/default.nix
@@ -26,7 +26,7 @@ let
       owner = "ARM-software";
       repo = "arm-trusted-firmware";
       rev = "v${version}";
-      sha256 = "sha256-CAuftVST9Fje/DWaaoX0K2SfWwlGMaUFG4huuwsTOSU=";
+      hash = "sha256-CAuftVST9Fje/DWaaoX0K2SfWwlGMaUFG4huuwsTOSU=";
     };
 
     depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/support/overlay/crust-firmware/default.nix
+++ b/support/overlay/crust-firmware/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     owner = "crust-firmware";
     repo = "crust";
     rev = "v${version}";
-    sha256 = "sha256-zalBVP9rI81XshcurxmvoCwkdlX3gMw5xuTVLOIymK4=";
+    hash = "sha256-zalBVP9rI81XshcurxmvoCwkdlX3gMw5xuTVLOIymK4=";
   };
 
   depsBuildBuild = [

--- a/support/overlay/default.nix
+++ b/support/overlay/default.nix
@@ -1,1 +1,1 @@
-{ pkgs }: pkgs.extend (import ./overlay.nix)
+{ pkgs ? import ../../nixpkgs.nix {} }: pkgs.extend (import ./overlay.nix)

--- a/support/overlay/gxlimg/default.nix
+++ b/support/overlay/gxlimg/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "repk";
     repo = pname;
     rev = "c545568fdd6a0470da4265a3532f5e652646707f";
-    sha256 = "05799f3gdxjqcv0s7bba724n8pxr0hldcj0p5n9ab92vgasgnpcq";
+    hash = "sha256-mF37tHpbpKWSLRdI1igEuV9kiThqraPBZlj29oZL6RQ=";
   };
 
   buildInputs = [

--- a/support/overlay/make_ext4fs/default.nix
+++ b/support/overlay/make_ext4fs/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
   src = fetchgit {
     url = "git://git.openwrt.org/project/make_ext4fs.git";
     rev = "eebda1d55d9701ace2700d7ae461697fadf52d1f";
-    sha256 = "03lqd5qy3nli9mmnlbgxwsplwz8v10cyjyzl1fxcfz8jvzr00c61";
+    hash = "sha256-wTAA8t8Sfce6C/R76RkIG31Or+b9LWprTZHa4XFpmA4=";
   };
 
   patches = [

--- a/support/overlay/meson64-tools/default.nix
+++ b/support/overlay/meson64-tools/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "angerman";
     repo = pname;
     rev = "a2d57d11fd8b4242b903c10dca9d25f7f99d8ff0";
-    sha256 = "1487cr7sv34yry8f0chaj6s2g3736dzq0aqw239ahdy30yg7hb2v";
+    hash = "sha256-Wyx4ngfDN6jSEBwrgH8z44wntJEKMuCQz56MrU9mB5E=";
   };
 
   buildInputs = with buildPackages; [ openssl bison yacc flex bc python3 ];

--- a/support/overlay/overlay.nix
+++ b/support/overlay/overlay.nix
@@ -149,5 +149,26 @@ in
         ;
       })
     ;
+
+    fetchzip =
+      args:
+      final.fetchzip (args // {
+        name =
+          args.name or (
+            builtins.concatStringsSep "-" [
+              (builtins.baseNameOf args.url)
+              "source"
+            ]
+          )
+        ;
+      })
+    ;
+
+    # Forbid fetchurl
+    fetchurl =
+      args:
+      throw "The `fetchurl` fetcher is disallowed in Tow-Boot. Use `fetchzip` for archives."
+      {}
+    ;
   });
 }

--- a/support/overlay/overlay.nix
+++ b/support/overlay/overlay.nix
@@ -4,7 +4,7 @@ let
   inherit (final) lib;
 in
 {
-  make_ext4fs = final.callPackage ./make_ext4fs { };
+  make_ext4fs = final.Tow-Boot.callPackage ./make_ext4fs { };
 
   Tow-Boot = lib.makeScope final.newScope (self:
 

--- a/support/overlay/overlay.nix
+++ b/support/overlay/overlay.nix
@@ -121,5 +121,21 @@ in
         ;
       })
     ;
+
+    fetchgit =
+      args:
+      final.fetchgit (args // {
+        name =
+          args.name or (
+            builtins.concatStringsSep "-" [
+              (builtins.baseNameOf args.url)
+              # NOTE: using `or ""` to make this error out in `fetchFromGitHub` instead of here.
+              (args.rev or args.tag or "")
+              "source"
+            ]
+          )
+        ;
+      })
+    ;
   });
 }

--- a/support/overlay/overlay.nix
+++ b/support/overlay/overlay.nix
@@ -137,5 +137,17 @@ in
         ;
       })
     ;
+
+    fetchpatch =
+      args:
+      final.fetchpatch (args // {
+        name =
+          args.name or (
+            (builtins.baseNameOf args.url)
+            # NOTE: not appending `-source`, this will keep only the filename, and thus the `.patch` ending.
+          )
+        ;
+      })
+    ;
   });
 }


### PR DESCRIPTION
### Rationale

One common pitfall with the way Nixpkgs fetches its sources, is how it strips the input details of `source` artifacts, and ends-up with store paths matching `/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-source`.

This has the benefit of keeping the output hashes the same when the FOD changes in an irrelevant manner (e.g. git repository moves to another GitHub owner; source tarball is mirrored with different names).

It does have the drawback of making it easy to accidentally keep using a store path from a previous successful fetch. The store path, within Nix semantics, refers to the combination of `hash ⨁ name`. Since `name` is always `source` with Nixpkgs fetchers, it effectively boils down to reference fetched artifacts by its `hash` only. Nix will happily keep using the “wrong” (according to the user) source file, since the only input (`hash`) already exists.

> ***FOD***: *Fixed Output Derivation*

* * *

### Solution

To work around this issue ***within Tow-Boot artifacts only***, we can override the fetchers to pass around a *somewhat useful* `name`. In turn this makes Nix look for the combination of `hash ⨁ $some_inputs`, where we're encoding *some inputs* into the `name` of the FOD.

The inputs vary according to their fetcher, but represent generally these two things:

 - For improved UX, a useful name (i.e. file name, repo name)
 - For working around the issue, a precise-enough name that will change when changing the source provenance (i.e. revision/tag, file name).

In addition, we're moving away from the (accidentally) used `fetchurl` fetcher; it is preferable to use `fetchzip` when fetching archives. (Yes, including non-`.zip` archives.)


* * *

### What was done

To check this was proper, and would actually do what I intend it to do (that is, helping a developer who's not deeply Nix aware), I "tried to update a U-Boot input", doing the easy mistake:

```diff
diff --git a/modules/tow-boot/src.nix b/modules/tow-boot/src.nix
index 48b74b5..04d1545 100644
--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -78,6 +78,7 @@ in
           "2023.10" = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
           "2024.01" = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
           "2024.04" = "sha256-IlaDdjKq/Pq2orzcU959h93WXRZfvKBGDO/MFw9mZMg=";
+          "2024.07" = "sha256-IlaDdjKq/Pq2orzcU959h93WXRZfvKBGDO/MFw9mZMg=";
         };
         Tow-Boot = {
           "tb-2023.07-007" = "sha256-qEVvvnKy3fdFmU7Qn1U2PMqhf8p228v6+4XtkVGgQgk=";
```

(Please disregard the invalid hashes... see explanation for the move to `fetchzip`. I made this demo before fixing that.)

**Before**

The existing source gets used. Accidentally.

Notice the output paths referring to the "newer" version, but the actual outputs using the "older" version (seen in the generated config files).

```
# Prime the cache
.../Tow-Boot $ nix-build -A pine64-pineA64LTS --arg configuration '{ Tow-Boot.buildUBoot = true; Tow-Boot.uBootVersion = "2024.04"; }'
...

# Try to build the new U-Boot
.../Tow-Boot $ nix-build -A pine64-pineA64LTS --arg configuration '{ Tow-Boot.buildUBoot = true; Tow-Boot.uBootVersion = "2024.07"; }'
trace: Using default Nixpkgs revision 'f292b4964cb71f9dfbbd30dc9f511d6165cd109b'...
trace: ****************************************
trace: * Evaluating device: pine64-pineA64LTS *
trace: ****************************************

...

/nix/store/8n2pfb1il8a53cm6la0q89jx2z5k5738-U-Boot.pine64-pineA64LTS.2024.07-008-pre
# Notice:  --------------------------------------------------------- ^^^^^^^

~/.../Tow-Boot/development 130 $ grep 2024 result/config/*.config
result/config/noenv.config:# U-Boot 2024.04 Configuration
result/config/spi.config:# U-Boot 2024.04 Configuration
# Notice:  ---------------------- ^^^^^^^
```

**After**

Erroring out as expected.

```
# Prime the cache
.../Tow-Boot $ nix-build -A pine64-pineA64LTS --arg configuration '{ Tow-Boot.buildUBoot = true; Tow-Boot.uBootVersion = "2024.04"; }'
...

# Try to build the new U-Boot
.../Tow-Boot $ nix-build -A pine64-pineA64LTS --arg configuration '{ Tow-Boot.buildUBoot = true; Tow-Boot.uBootVersion = "2024.07"; }'
trace: Using default Nixpkgs revision 'f292b4964cb71f9dfbbd30dc9f511d6165cd109b'...
trace: ****************************************
trace: * Evaluating device: pine64-pineA64LTS *
trace: ****************************************

...

building '/nix/store/wrg19z54gsns66hbildssp4qsxxc168c-u-boot-2024.07.tar.bz2-source.drv'...

trying ftp://ftp.denx.de/pub/u-boot/u-boot-2024.07.tar.bz2
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 24.8M  100 24.8M    0     0  2520k      0  0:00:10  0:00:10 --:--:-- 3051k
unpacking source archive /build/u-boot-2024.07.tar.bz2
error: hash mismatch in fixed-output derivation '/nix/store/wrg19z54gsns66hbildssp4qsxxc168c-u-boot-2024.07.tar.bz2-source.drv':
        likely URL: ftp://ftp.denx.de/pub/u-boot/u-boot-2024.07.tar.bz2
         specified: sha256-IlaDdjKq/Pq2orzcU959h93WXRZfvKBGDO/MFw9mZMg=
            got:    sha256-mJ2TBy0Y5ZtcGFgtU5RKr0UDUp5FWzojbFb+o/ebRJU=
error: 1 dependencies of derivation '/nix/store/ykg61wmaqv8y12hyzkzd55cys6j4jm7d-U-Boot-pine64-lts_defconfig-boot-installer-aarch64-unknown-linux-gnu-2024.07-008-pre.drv' failed to build
...
```
