### PR TITLE
Add NanoPi Neo4

### DIFF
--- a/boards/friendlyElec-nanoPiNeo4/default.nix
+++ b/boards/friendlyElec-nanoPiNeo4/default.nix
@@ -1,0 +1,17 @@
+{
+  device = {
+    manufacturer = "FriendlyELEC";
+    name = "NanoPi Neo4";
+    identifier = "friendlyElec-nanoPiNeo4";
+    productPageURL = "https://wiki.friendlyelec.com/wiki/index.php/NanoPi_NEO4";
+    supportLevel = "best-effort";
+  };
+
+  hardware = {
+    soc = "rockchip-rk3399";
+  };
+
+  Tow-Boot = {
+    defconfig = "nanopi-neo4-rk3399_defconfig";
+  };
+}


### PR DESCRIPTION
Tow-Boot manages to boot successfully on NanoPi Neo4.

Installation instructions used (with https://github.com/armbian/rkbin/blob/master/rk33/rk3399_loader_v1.30.130.bin):
```
nix-build -A friendlyElec-nanoPiNeo4
nix-shell -p rkdeveloptool

# Upload loader
rkdeveloptool db rk3399_loader_v1.30.130.bin
sleep 2

# Erase EMMC (WARNING!!!)
rkdeveloptool ef

# Install Tow-Boot
rkdeveloptool wl 0x0 ./result/shared.disk-image.img

# Reset device
rkdeveloptool rd
```

Working:
- successfully booted NixOS official ARM ISO graphical installer 🎉 
- UART console is working fine, at 115200 baud
- Boot on SDcard EFI partition works (GRUB shows up on UART)

Not working:
- No HDMI output in uboot
- Not able to boot on USB