### PR TITLE
Abootimg support

### DIFF
--- a/boards/qualcomm-sdm845/default.nix
+++ b/boards/qualcomm-sdm845/default.nix
@@ -1,0 +1,72 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkMerge
+    mkIf
+  ;
+  inherit (config.Tow-Boot) buildUBoot;
+in
+{
+  device = {
+    manufacturer = "Qualcomm";
+    name = "SDM845 Mobile Phones";
+    identifier = "qualcomm-sdm845";
+    productPageURL = "https://www.qualcomm.com/products/mobile/snapdragon/smartphones/snapdragon-8-series-mobile-platforms/snapdragon-845-mobile-platform";
+    supportLevel = "experimental";
+  };
+
+  hardware = {
+    soc = "qualcomm-sdm845";
+  };
+
+  Tow-Boot = {
+    buildUBoot = true;
+    uBootVersion = lib.mkForce "2026.01";
+    defconfig = "qcom_defconfig";
+    variant = lib.mkDefault "androidboot";
+
+    patches = lib.mkForce [];
+
+    phone-ux = {
+      enable = true;
+      blind = true;
+      wip = {
+        # LED configuration depends on specific device
+        # These are placeholders and should be adjusted per device
+        led_R = "led-red";
+        led_G = "led-green";
+        led_B = "led-blue";
+        mmcSD   = "1";
+        mmcEMMC = "0";
+      };
+    };
+    config = mkMerge [
+      [(helpers: with helpers; {
+        # Fix TEXT_OFFSET for ABL bootloader validation
+        # ABL on newer Android versions (Q/R) validates TEXT_OFFSET = 0x00080000
+        TEXT_BASE = option (freeform "0x80080000");
+
+        HAVE_SYS_UBOOT_START = option yes;
+
+        # Disable framebuffer clear to avoid distorting U-Boot output
+        NO_FB_CLEAR = no;
+
+        # Mark as optional to allow build with warnings instead of errors
+        MSM_SMESM = option yes;
+        DTB_RESELECT = option yes;
+
+        # Ensure USB gadget manufacturer is set
+        USB_GADGET_MANUFACTURER = option (freeform ''"Qualcomm"'');
+      })]
+      # Requires Tow-Boot patches - make optional for stock U-Boot base
+      (mkIf (!buildUBoot) [(helpers: with helpers;{
+        BUTTON_GPIO = option yes;
+        LED_GPIO = option yes;
+      })])
+    ];
+    touch-installer = {
+      targetBlockDevice = "/dev/sda";
+    };
+  };
+}

--- a/doc/variants.md
+++ b/doc/variants.md
@@ -4,6 +4,7 @@ Variants
  - `noenv` does not save environment anywhere
  - `spi` saves the environment to the SPI device
  - `mmcboot` does not save environment anywhere
+ - `androidboot` does not save environment anywhere (for Android chainloading)
 
 
 `noenv`
@@ -38,6 +39,22 @@ storage.
 This variant is to be used on systems with eMMC Hardware boot partitions
 as dedicated firmware storage.
 
+
+`androidboot`
+-------------
+
+This variant is designed to be chainloaded from Android Boot Loader (ABL) on
+Qualcomm and other Android-based devices. Like `noenv`, it does not save the
+environment anywhere.
+
+This variant is specifically for Android phones where:
+- U-Boot is chainloaded from the device's ABL (Android Boot Loader)
+- The framebuffer is inherited from ABL, avoiding complex display initialization
+- The boot image format is compatible with Android fastboot flashing
+
+Typical use cases include Qualcomm Snapdragon devices (SDM845, etc.) and other
+Android phones with unlocked bootloaders that allow chainloading alternative
+boot firmware.
 
 
 * * *

--- a/modules/build.nix
+++ b/modules/build.nix
@@ -97,7 +97,14 @@ in
           cp -rt $out/binaries/ ${firmware}/binaries/*
           cp -rt $out/config/ ${firmware}/config/*
           cp -rt $out/diff/ ${firmware}/diff/*
-          cp ${sharedDiskImage} $out/shared.disk-image.img
+          # For androidboot variant, copy directory contents; otherwise copy file
+          if [ -d "${sharedDiskImage}" ]; then
+            for file in "${sharedDiskImage}"/*; do
+              cp -v "$file" $out/
+            done
+          else
+            cp "${sharedDiskImage}" $out/shared.disk-image.img
+          fi
           ${optionalString (firmwareMMCBoot != null) ''
             cp -rt $out/binaries/ ${firmwareMMCBoot}/binaries/*
             cp -rt $out/config/ ${firmwareMMCBoot}/config/*

--- a/modules/hardware/default.nix
+++ b/modules/hardware/default.nix
@@ -15,6 +15,7 @@ in
     ./allwinner
     ./amlogic
     ./rockchip
+    ./qualcomm
     ./generic.nix
   ];
 

--- a/modules/hardware/qualcomm/default.nix
+++ b/modules/hardware/qualcomm/default.nix
@@ -1,0 +1,68 @@
+{ config, lib, ... }:
+
+let
+  inherit (lib)
+    mkIf
+    mkMerge
+    mkOption
+    types
+  ;
+  cfg = config.hardware.socs;
+in
+{
+  options = {
+    hardware.socs = {
+      qualcomm-sdm845.enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable when targeting Qualcomm Snapdragon 845 (SDM845).";
+        internal = true;
+      };
+    };
+  };
+
+  config = mkMerge [
+    {
+      hardware.socList = [
+        "qualcomm-sdm845"
+      ];
+    }
+    (mkIf cfg.qualcomm-sdm845.enable {
+      system.system = "aarch64-linux";
+
+      Tow-Boot = {
+        # Newer Qualcomm devices use UFS as storage
+        # On bootloader unlocked devices we store image in "boot"
+        firmwarePartition = {
+          offset = 0;
+          length = 16 * 1024 * 1024;
+        };
+        builder = {
+          additionalArguments = {
+            ARCH = "arm64";
+          };
+          installPhase = ''
+            echo ":: Preparing Qualcomm SDM845 binaries..."
+            (PS4=" $ "; set -x
+
+            mkdir $out/binaries/dtb
+            cp -v u-boot.bin $out/binaries/u-boot.bin
+
+            if [ -f u-boot-nodtb.bin ]; then
+              cp -v u-boot-nodtb.bin $out/binaries/
+            fi
+
+            for dtb in dts/upstream/src/arm64/qcom/sdm845-*.dtb; do
+              [ -f "$dtb" ] && cp -v "$dtb" $out/binaries/dtb
+            done
+
+            if [ -f u-boot.itb ]; then
+              cp -v u-boot.itb $out/binaries/
+            fi
+            )
+          '';
+        };
+      };
+    })
+  ];
+}

--- a/modules/tow-boot/builder.nix
+++ b/modules/tow-boot/builder.nix
@@ -170,6 +170,7 @@ in
             buildPackages.swig
             buildPackages.gnutls  # For tools/mkeficapsule
             buildPackages.libuuid # For tools/mkeficapsule
+            buildPackages.unixtools.xxd # For xxd
             (buildPackages.python3.withPackages (p: [
               p.libfdt
               p.pyelftools
@@ -206,7 +207,7 @@ in
             runHook preConfigure
             make ${defconfig}
             cat $extraConfigPath >> .config
-            make $makeFlags "''${makeFlagsArray[@]}" oldconfig
+            make $makeFlags "''${makeFlagsArray[@]}" olddefconfig
 
             runHook postConfigure
 

--- a/modules/tow-boot/config.nix
+++ b/modules/tow-boot/config.nix
@@ -119,7 +119,7 @@ in
       TPL_ENV_IS_NOWHERE = mkDefault no;
       SPL_ENV_IS_NOWHERE = mkDefault no;
     })
-    (mkIf (variant == "noenv" || variant == "boot-installer") (helpers: with helpers; {
+    (mkIf (variant == "noenv" || variant == "boot-installer" || variant == "androidboot") (helpers: with helpers; {
       ENV_IS_NOWHERE = yes;
       TPL_ENV_IS_NOWHERE = option yes;
       SPL_ENV_IS_NOWHERE = option yes;

--- a/modules/tow-boot/config.nix
+++ b/modules/tow-boot/config.nix
@@ -148,11 +148,11 @@ in
       # For now, it's outright disabled, we will need to re-evaluate our
       # infra to work with bootstd, but only after a larger proportion of
       # the devices default to `bootstd`.
-      BOOTSTD = no;
-      BOOTSTD_DEFAULTS = no;
-      DISTRO_DEFAULTS = yes;
-      USE_BOOTCOMMAND = yes;
-      BOOTCOMMAND = freeform ''"run distro_bootcmd"'';
+      BOOTSTD = option no;
+      BOOTSTD_DEFAULTS = option no;
+      DISTRO_DEFAULTS = option yes;
+      USE_BOOTCOMMAND = option yes;
+      BOOTCOMMAND = option (freeform ''"run distro_bootcmd"'');
     })
 
     # Logo handling

--- a/modules/tow-boot/disk-image.nix
+++ b/modules/tow-boot/disk-image.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 let
   inherit (lib)
@@ -85,12 +85,54 @@ in
           # May be overriden by platforms.
           else "F8"
         );
-        raw = lib.mkIf config.Tow-Boot.writeBinaryToFirmwarePartition "${config.Tow-Boot.outputs.firmware}/binaries/Tow-Boot.noenv.bin";
+        raw = lib.mkIf config.Tow-Boot.writeBinaryToFirmwarePartition "${config.Tow-Boot.outputs.firmware}/binaries/Tow-Boot.${config.Tow-Boot.variant}.bin";
       };
 
       outputs = {
-        # Round-about, but this is our stable interface now.
-        diskImage = config.Tow-Boot.diskImage.output;
+        # For androidboot variant, create Android boot image instead of disk image
+        diskImage =
+          if config.Tow-Boot.variant == "androidboot"
+          then pkgs.callPackage (
+            { runCommand, android-tools }:
+            runCommand "${config.Tow-Boot.outputName}.${config.device.identifier}.androidboot.img" {} ''
+              mkdir -p $out
+
+              # Follow official U-Boot Qualcomm docs:
+              # https://docs.u-boot.org/en/stable/board/qualcomm/board.html
+              #
+              # 1. Gzip u-boot-nodtb.bin
+              # 2. Append DTB to create u-boot-nodtb.bin.gz-dtb
+              # 3. Package with mkbootimg
+
+              echo "Creating Android boot image for SDM845..."
+
+              # Gzip the U-Boot binary (use u-boot-nodtb.bin if available, otherwise the full binary)
+              if [ -f ${config.Tow-Boot.outputs.firmware}/binaries/u-boot-nodtb.bin ]; then
+                UBOOT_BIN="${config.Tow-Boot.outputs.firmware}/binaries/u-boot-nodtb.bin"
+              else
+                UBOOT_BIN="${config.Tow-Boot.outputs.firmware}/binaries/Tow-Boot.${config.Tow-Boot.variant}.bin"
+              fi
+
+              echo "Compressing U-Boot binary..."
+              gzip -n -9 -k -c "$UBOOT_BIN" > u-boot-nodtb.bin.gz
+
+              # Create Android boot image with mkbootimg
+              echo "Building without ramdisk (U-Boot standalone)..."
+              ${android-tools}/bin/mkbootimg \
+                --kernel u-boot-nodtb.bin.gz \
+                --output $out/Tow-Boot.androidboot.img \
+                --pagesize 4096 \
+                --base 0x00000000 \
+                --kernel_offset 0x00008000 \
+                --ramdisk_offset 0x01000000 \
+                --tags_offset 0x00000100 \
+                --board ""
+
+              echo "Created Android boot image:"
+              ls -lh $out/
+            ''
+          ) {}
+          else config.Tow-Boot.diskImage.output;
       };
     };
   };

--- a/modules/tow-boot/options.nix
+++ b/modules/tow-boot/options.nix
@@ -103,7 +103,7 @@ in
       };
       variant = mkOption {
         # TIP: look for `composeConfig` for customizing `Tow-Boot.variant`.
-        type = types.enum [ "noenv" "spi" "mmcboot" "boot-installer" ];
+        type = types.enum [ "noenv" "spi" "mmcboot" "boot-installer" "androidboot" ];
         default = "noenv";
         description = ''
           Build variant for this eval.

--- a/modules/tow-boot/src.nix
+++ b/modules/tow-boot/src.nix
@@ -78,6 +78,13 @@ in
           "2023.10" = "sha256-4A5sbwFOBGEBc50I0G8yiBHOvPWuEBNI9AnLvVXOaQA=";
           "2024.01" = "sha256-uZYR8e0je/NUG9yENLaMlqbgWWcGH5kkQ8swqr6+9bM=";
           "2024.04" = "sha256-GKhT/jn6160DqQzC1Cda6u1tppc13vrDSSuAUIhD3Uo=";
+          "2024.07" = "sha256-9ZHamrkO89az0XN2bQ3f+QxO1zMGgIl0hhF985DYPI8=";
+          "2024.10" = "sha256-so2vSsF+QxVjYweL9RApdYQTf231D87ZsS3zT2GpL7A=";
+          "2025.01" = "sha256-ze99UHyT8bvZ8BXqm8IfoHQmhIFAVQGUWrxvhU1baG8=";
+          "2025.04" = "sha256-Q5077ylu/9VBML5qcxxbEYvn/d1/zGY8y8X7GClNhxg=";
+          "2025.07" = "sha256-D5M/bFpCaJW/MG6T5qxTxghw5LVM2lbZUhG+yZ5jvsc=";
+          "2025.10" = "sha256-tPAyhI5WzI8hOtWfkTLAhNu7YyvCkXbQJOWCIODv30o=";
+          "2026.01" = "sha256-tg1YZc79vHXajaQVbFbEWOAN51pJuAwaLlipbjCtDVQ=";
         };
         Tow-Boot = {
           "tb-2023.07-007" = "sha256-qEVvvnKy3fdFmU7Qn1U2PMqhf8p228v6+4XtkVGgQgk=";


### PR DESCRIPTION
Hi @samueldr ,

this PR adds support for Qualcomm devices and introduces new image format for Android devices. Also adds newer versions of u-boot.

The goal is to support SDM845 by having single u-boot bootloader which in runtime fingerprints the device based on the `qcom,board-id` property from `MSM_SMEM`. The autodetection will be part of u-boot upstream once finished.

Then it will provide the correct DTB for the Linux kernel to boot.

The idea is to take just the `u-boot` binary itself and use it as dependency for mobile-nixos where there will be also just single kernel for SDM845 devices.

The reason u-boot is chainloaded is that Linux kernel can't easily change the DTB (best way would be to `kexec` new kernel) and also the ABL provides sometimes confusing cmdline options.

Not to mention Pixel3 that requires TEXT_OFFSET hack to even boot.

